### PR TITLE
[BSENG-2318] Switch to GitHub runners, use matrix strategy for test execution

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -10,8 +10,6 @@ jobs:
     name: Run weekly tests
     runs-on: ubuntu-latest
     timeout-minutes: 1440
-    outputs:
-      failed_tests: ${{ steps.collect-failed-tests.outputs.failed_tests }}
     strategy:
       max-parallel: 3
       fail-fast: false
@@ -102,31 +100,48 @@ jobs:
           ref: ${{ matrix.branch }}
           wait_interval: 60
 
-      - name: Collect failed tests
-        id: collect-failed-tests
-        env:
-          WORKFLOW_URL: ${{ steps.dispatched-tests.outputs.workflow_url }}
-        if: ${{ failure() }}
+      - name: Collect result
+        id: collect-result
+        if: always()
         run: |
-          failed_tests=""
-          if [ "${{ steps.dispatched-tests.outcome }}" != "success" ]; then
-            failed_tests+="[${{ matrix.repo }}]($WORKFLOW_URL), "
-          fi
-          # Set the output variable to pass the failed tests to the next job
-          echo "failed_tests=$failed_tests" >> "$GITHUB_OUTPUT"
+          result=$(cat <<-END
+              {
+                  "job-index": "${{ strategy.job-index }}",
+                  "repo": "${{ matrix.repo }}",
+                  "branch": "${{ matrix.branch }}",
+                  "workflow_file_name":"${{ matrix.workflow_file_name }}",
+                  "conclusion": "${{ steps.dispatched-tests.outcome }}",
+                  "workflow_url": "${{ steps.dispatched-tests.outputs.workflow_url }}"
+              }
+          END
+          )
+          echo $result > "result-${{ strategy.job-index }}.json"
 
-  notify-on-failure:
-    needs: [weekly-tests]
-    if: ${{ failure() }}
-    name: Notify Mattermost Channel
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "result-${{ strategy.job-index }}"
+          path: "result-${{ strategy.job-index }}.json"
+
+  notify:
+    needs: weekly-tests
+    if: always()  # these needs to be run always
+    name: Notify SolEng with results
     runs-on: ubuntu-latest
     steps:
-      - name: Create the Mattermost Message
-        env:
-          WEEKLY_TESTS: ${{ needs.weekly-tests.outputs.failed_tests }}
+      - name: Collect results
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: Install jq
         run: |
-          echo "{\"text\":\":robot_face: [Weekly tests]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) have failed for these projects: $WEEKLY_TESTS\"}" > mattermost.json
-
+           sudo apt update
+           sudo apt install jq -y
+      - name: Create the Mattermost Message
+        run: |
+          url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          results=$(jq -s '.[] | ["- [\(.repo) (\(.branch), \(.workflow_file_name))](\(.workflow_url)) \(if .conclusion == "success" then ":gh-success-octicon-checkcirclefillicon:" else ":gh-failure-octicon-xcirclefillicon:" end)"]' result-*.json | jq -r 'join("\n")')
+          jq -n --arg url "$url" --arg results "$results" '{text: ":robot_face: @soleng results from [Weekly tests](\($url)):\n\($results)"}' > mattermost.json
       - uses: mattermost/action-mattermost-notify@master
         env:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   tests-1:
     name: Run first set of tests
-    runs-on: [self-hosted, small, jammy, x64]
     timeout-minutes: 1440
     outputs:
       failed_tests: ${{ steps.collect-failed-tests.outputs.failed_tests }}
@@ -235,7 +234,6 @@ jobs:
 
   tests-2:
     name: Run second set of tests
-    runs-on: [self-hosted, small, jammy, x64]
     timeout-minutes: 1440
     outputs:
       failed_tests: ${{ steps.collect-failed-tests.outputs.failed_tests }}

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Collect failed tests
         id: collect-failed-tests
         env:
-          WORKFLOW_URL: ${{ steps.dispatched-test.outputs.workflow_url }}
+          WORKFLOW_URL: ${{ steps.dispatched-tests.outputs.workflow_url }}
         if: ${{ failure() }}
         run: |
           failed_tests=""

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -6,7 +6,7 @@ on:
     - cron: "0 0 * * SAT"
 
 jobs:
-  weekle-tests:
+  weekly-tests:
     name: Run weekly tests
     runs-on: ubuntu-latest
     timeout-minutes: 1440
@@ -114,16 +114,16 @@ jobs:
           echo "failed_tests=$failed_tests" >> "$GITHUB_OUTPUT"
 
   notify-on-failure:
-    needs: [weekle-tests]
+    needs: [weekly-tests]
     if: ${{ failure() }}
     name: Notify Mattermost Channel
     runs-on: ubuntu-latest
     steps:
       - name: Create the Mattermost Message
         env:
-          WEEKLE_TESTS: ${{ needs.weekle-tests.outputs.failed_tests }}
+          WEEKLY_TESTS: ${{ needs.weekly-tests.outputs.failed_tests }}
         run: |
-          echo "{\"text\":\":robot_face: [Weekly tests]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) have failed for these projects: $WEEKLE_TESTS\"}" > mattermost.json
+          echo "{\"text\":\":robot_face: [Weekly tests]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) have failed for these projects: $WEEKLY_TESTS\"}" > mattermost.json
 
       - uses: mattermost/action-mattermost-notify@master
         env:

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -16,86 +16,86 @@ jobs:
       matrix:
         max-parallel: 3
         include:
-          - charm: charm-advanced-routing
+          - repo: charm-advanced-routing
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-apt-mirror
+          - repo: charm-apt-mirror
             workflow_file_name: check.yaml
             branch: main
-          - charm: charm-cloudsupport
+          - repo: charm-cloudsupport
             workflow_file_name: check.yaml
             branch: main
-          - charm: charm-duplicity
+          - repo: charm-duplicity
             workflow_file_name: check.yaml
             branch: master
-          - charm: hardware-observer-operator
+          - repo: hardware-observer-operator
             workflow_file_name: check.yaml
             branch: master
-          - charm: hardware-observer-operator-integration
+          - repo: hardware-observer-operator
+            workflow_file_name: cos_integration.yaml
+            branch: master
+          - repo: charm-juju-backup-all
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-juju-backup-all
-            workflow_file_name: check.yaml
-            branch: master
-          - charm: charm-juju-local
+          - repo: charm-juju-local
             workflow_file_name: check.yaml
             branch: main
-          - charm: charm-kubernetes-service-checks
+          - repo: charm-kubernetes-service-checks
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-local-users
+          - repo: charm-local-users
             workflow_file_name: check.yaml
             branch: main
-          - charm: charm-logrotated
+          - repo: charm-logrotated
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-nginx
+          - repo: charm-nginx
             workflow_file_name: check.yaml
             branch: main
-          - charm: charm-openstack-service-checks
+          - repo: charm-openstack-service-checks
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-prometheus-blackbox-exporter
+          - repo: charm-prometheus-blackbox-exporter
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-prometheus-libvirt-exporter
+          - repo: charm-prometheus-libvirt-exporter
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-simple-streams
+          - repo: charm-simple-streams
             workflow_file_name: check.yaml
             branch: main
-          - charm: charm-storage-connector
+          - repo: charm-storage-connector
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-sysconfig
+          - repo: charm-sysconfig
             workflow_file_name: check.yaml
             branch: master
-          - charm: charm-userdir-ldap
+          - repo: charm-userdir-ldap
             workflow_file_name: check.yaml
             branch: master
-          - charm: prometheus-hardware-exporter
+          - repo: prometheus-hardware-exporter
             workflow_file_name: check.yaml
             branch: main
-          - charm: prometheus-juju-exporter
+          - repo: prometheus-juju-exporter
             workflow_file_name: pr.yaml
             branch: main
-          - charm: prometheus-juju-backup-all-exporter
+          - repo: prometheus-juju-backup-all-exporter
             workflow_file_name: pr.yaml
             branch: main
-          - charm: snap-tempest
+          - repo: snap-tempest
             workflow_file_name: pr.yaml
             branch: main
-          - charm: charmed-openstack-upgrader
+          - repo: charmed-openstack-upgrader
             workflow_file_name: check.yaml
             branch: main
 
     steps:
-      - name: Tests for ${{ matrix.charm }}
+      - name: Running ${{ matrix.workflow_file_name }} tests for ${{ matrix.repo }}
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         id: dispatched-tests
         with:
           owner: canonical
-          repo: ${{ matrix.charm }}
+          repo: ${{ matrix.repo }}
           github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
           workflow_file_name: ${{ matrix.workflow_file_name }}
           ref: ${{ matrix.branch }}
@@ -107,23 +107,22 @@ jobs:
         run: |
           failed_tests=""
           if [ "${{ steps.dispatched-tests.outcome }}" != "success" ]; then
-            failed_tests+="[${{ matrix.charm }}](https://github.com/canonical/${{ matrix.charm }}/actions), "
+            failed_tests+="[${{ matrix.repo }}](https://github.com/canonical/${{ matrix.repo }}/actions), "
           fi
           # Set the output variable to pass the failed tests to the next job
           echo "failed_tests=$failed_tests" >> "$GITHUB_OUTPUT"
 
   notify-on-failure:
-    needs: [tests-1, tests-2]
+    needs: [weekle-tests]
     if: ${{ failure() }}
     name: Notify Mattermost Channel
     runs-on: ubuntu-latest
     steps:
       - name: Create the Mattermost Message
         env:
-          FAILED_TESTS_1: ${{ needs.tests-1.outputs.failed_tests }}
-          FAILED_TESTS_2: ${{ needs.tests-2.outputs.failed_tests }}
+          WEEKLE_TESTS: ${{ needs.weekle-tests.outputs.failed_tests }}
         run: |
-          echo "{\"text\":\":robot_face: Weekly tests have failed for these projects: $FAILED_TESTS_1 $FAILED_TESTS_2\"}" > mattermost.json
+          echo "{\"text\":\":robot_face: [Weekly tests]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) have failed for these projects: $WEEKLE_TESTS\"}" > mattermost.json
 
       - uses: mattermost/action-mattermost-notify@master
         env:

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -13,8 +13,8 @@ jobs:
     outputs:
       failed_tests: ${{ steps.collect-failed-tests.outputs.failed_tests }}
     strategy:
+      max-parallel: 3
       matrix:
-        max-parallel: 3
         include:
           - repo: charm-advanced-routing
             workflow_file_name: check.yaml

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -6,177 +6,99 @@ on:
     - cron: "0 0 * * SAT"
 
 jobs:
-  tests-1:
-    name: Run first set of tests
+  weekle-tests:
+    name: Run weekly tests
+    runs-on: ubuntu-latest
     timeout-minutes: 1440
     outputs:
       failed_tests: ${{ steps.collect-failed-tests.outputs.failed_tests }}
+    strategy:
+      matrix:
+        max-parallel: 3
+        include:
+          - charm: charm-advanced-routing
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-apt-mirror
+            workflow_file_name: check.yaml
+            branch: main
+          - charm: charm-cloudsupport
+            workflow_file_name: check.yaml
+            branch: main
+          - charm: charm-duplicity
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: hardware-observer-operator
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: hardware-observer-operator-integration
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-juju-backup-all
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-juju-local
+            workflow_file_name: check.yaml
+            branch: main
+          - charm: charm-kubernetes-service-checks
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-local-users
+            workflow_file_name: check.yaml
+            branch: main
+          - charm: charm-logrotated
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-nginx
+            workflow_file_name: check.yaml
+            branch: main
+          - charm: charm-openstack-service-checks
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-prometheus-blackbox-exporter
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-prometheus-libvirt-exporter
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-simple-streams
+            workflow_file_name: check.yaml
+            branch: main
+          - charm: charm-storage-connector
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-sysconfig
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: charm-userdir-ldap
+            workflow_file_name: check.yaml
+            branch: master
+          - charm: prometheus-hardware-exporter
+            workflow_file_name: check.yaml
+            branch: main
+          - charm: prometheus-juju-exporter
+            workflow_file_name: pr.yaml
+            branch: main
+          - charm: prometheus-juju-backup-all-exporter
+            workflow_file_name: pr.yaml
+            branch: main
+          - charm: snap-tempest
+            workflow_file_name: pr.yaml
+            branch: main
+          - charm: charmed-openstack-upgrader
+            workflow_file_name: check.yaml
+            branch: main
+
     steps:
-      - name: Tests for charm-advanced-routing
+      - name: Tests for ${{ matrix.charm }}
         uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-advanced-routing
+        id: dispatched-tests
         with:
           owner: canonical
-          repo: charm-advanced-routing
+          repo: ${{ matrix.charm }}
           github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-      
-      - name: Tests for charm-apt-mirror
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-apt-mirror
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-apt-mirror
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for charm-cloudsupport
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-cloudsupport
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-cloudsupport
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for charm-duplicity
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-duplicity
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-duplicity
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for hardware-observer-operator
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: hardware-observer-operator
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: hardware-observer-operator
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: COS integration tests for hardware-observer-operator
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: hardware-observer-operator-integration
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: hardware-observer-operator
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: cos_integration.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-juju-backup-all
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-juju-backup-all
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-juju-backup-all
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-juju-local
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-juju-local
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-juju-local
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-kubernetes-service-checks
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-kubernetes-service-checks
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-kubernetes-service-checks
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-local-users
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-local-users
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-local-users
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for charm-logrotated
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-logrotated
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-logrotated
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-nginx
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-nginx
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-nginx
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for charm-openstack-service-checks
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-openstack-service-checks
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-openstack-service-checks
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-prometheus-blackbox-exporter
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-prometheus-blackbox-exporter
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-prometheus-blackbox-exporter
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
+          workflow_file_name: ${{ matrix.workflow_file_name }}
+          ref: ${{ matrix.branch }}
           wait_interval: 60
 
       - name: Collect failed tests
@@ -184,213 +106,8 @@ jobs:
         if: ${{ failure() }}
         run: |
           failed_tests=""
-          if [ "${{ steps.charm-advanced-routing.outcome }}" != "success" ]; then
-            failed_tests+="[charm-advanced-routing](https://github.com/canonical/charm-advanced-routing/actions), "
-          fi
-          if [ "${{ steps.charm-apt-mirror.outcome }}" != "success" ]; then
-            failed_tests+="[charm-apt-mirror](https://github.com/canonical/charm-apt-mirror/actions), "
-          fi
-          if [ "${{ steps.charm-cloudsupport.outcome }}" != "success" ]; then
-            failed_tests+="[charm-cloudsupport](https://github.com/canonical/charm-cloudsupport/actions), "
-          fi
-          if [ "${{ steps.charm-duplicity.outcome }}" != "success" ]; then
-            failed_tests+="[charm-duplicity](https://github.com/canonical/charm-duplicity/actions), "
-          fi
-          if [ "${{ steps.hardware-observer-operator.outcome }}" != "success" ]; then
-            failed_tests+="[hardware-observer-operator](https://github.com/canonical/hardware-observer-operator/actions), "
-          fi
-          if [ "${{ steps.hardware-observer-operator-integration.outcome }}" != "success" ]; then
-            failed_tests+="[hardware-observer-operator-integration](https://github.com/canonical/hardware-observer-operator/actions), "
-          fi
-          if [ "${{ steps.charm-juju-backup-all.outcome }}" != "success" ]; then
-            failed_tests+="[charm-juju-backup-all](https://github.com/canonical/charm-juju-backup-all/actions), "
-          fi
-          if [ "${{ steps.charm-juju-local.outcome }}" != "success" ]; then
-            failed_tests+="[charm-juju-local](https://github.com/canonical/charm-juju-local/actions), "
-          fi
-          if [ "${{ steps.charm-kubernetes-service-checks.outcome }}" != "success" ]; then
-            failed_tests+="[charm-kubernetes-service-checks](https://github.com/canonical/charm-kubernetes-service-checks/actions), "
-          fi
-          if [ "${{ steps.charm-local-users.outcome }}" != "success" ]; then
-            failed_tests+="[charm-local-users](https://github.com/canonical/charm-local-users/actions), "
-          fi
-          if [ "${{ steps.charm-logrotated.outcome }}" != "success" ]; then
-            failed_tests+="[charm-logrotated](https://github.com/canonical/charm-logrotated/actions), "
-          fi
-          if [ "${{ steps.charm-nginx.outcome }}" != "success" ]; then
-            failed_tests+="[charm-nginx](https://github.com/canonical/charm-nginx/actions), "
-          fi
-          if [ "${{ steps.charm-nrpe.outcome }}" != "success" ]; then
-            failed_tests+="[charm-nrpe](https://github.com/canonical/charm-nrpe/actions), "
-          fi
-          if [ "${{ steps.charm-openstack-service-checks.outcome }}" != "success" ]; then
-            failed_tests+="[charm-openstack-service-checks](https://github.com/canonical/charm-openstack-service-checks/actions), "
-          fi
-          if [ "${{ steps.charm-prometheus-blackbox-exporter.outcome }}" != "success" ]; then
-            failed_tests+="[charm-prometheus-blackbox-exporter](https://github.com/canonical/charm-prometheus-blackbox-exporter/actions), "
-          fi
-          # Set the output variable to pass the failed tests to the next job
-          echo "failed_tests=$failed_tests" >> "$GITHUB_OUTPUT"
-
-  tests-2:
-    name: Run second set of tests
-    timeout-minutes: 1440
-    outputs:
-      failed_tests: ${{ steps.collect-failed-tests.outputs.failed_tests }}
-    steps:
-      - name: Tests for charm-prometheus-libvirt-exporter
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-prometheus-libvirt-exporter
-        with:
-          owner: canonical
-          repo: charm-prometheus-libvirt-exporter
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-simple-streams
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-simple-streams
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-simple-streams
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for charm-storage-connector
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-storage-connector
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-storage-connector
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-sysconfig
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-sysconfig
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-sysconfig
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for charm-userdir-ldap
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charm-userdir-ldap
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charm-userdir-ldap
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: master
-          wait_interval: 60
-
-      - name: Tests for prometheus-hardware-exporter
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: prometheus-hardware-exporter
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: prometheus-hardware-exporter
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for prometheus-juju-exporter
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: prometheus-juju-exporter
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: prometheus-juju-exporter
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: pr.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for prometheus-juju-backup-all-exporter
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: prometheus-juju-backup-all-exporter
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: prometheus-juju-backup-all-exporter
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for snap-tempest
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: snap-tempest
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: snap-tempest
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: pr.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Tests for charmed-openstack-upgrader
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: charmed-openstack-upgrader
-        if: ${{ always() }}
-        with:
-          owner: canonical
-          repo: charmed-openstack-upgrader
-          github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
-          workflow_file_name: check.yaml
-          ref: main
-          wait_interval: 60
-
-      - name: Collect failed tests
-        id: collect-failed-tests
-        if: ${{ failure() }}
-        run: |
-          failed_tests=""
-          if [ "${{ steps.charm-prometheus-libvirt-exporter.outcome }}" != "success" ]; then
-            failed_tests+="[charm-prometheus-libvirt-exporter](https://github.com/canonical/charm-prometheus-libvirt-exporter/actions), "
-          fi
-          if [ "${{ steps.charm-simple-streams.outcome }}" != "success" ]; then
-            failed_tests+="[charm-simple-streams](https://github.com/canonical/charm-simple-streams/actions), "
-          fi
-          if [ "${{ steps.charm-storage-connector.outcome }}" != "success" ]; then
-            failed_tests+="[charm-storage-connector](https://github.com/canonical/charm-storage-connector/actions), "
-          fi
-          if [ "${{ steps.charm-sysconfig.outcome }}" != "success" ]; then
-            failed_tests+="[charm-sysconfig](https://github.com/canonical/charm-sysconfig/actions), "
-          fi
-          if [ "${{ steps.charm-userdir-ldap.outcome }}" != "success" ]; then
-            failed_tests+="[charm-userdir-ldap](https://github.com/canonical/charm-userdir-ldap/actions), "
-          fi
-          if [ "${{ steps.prometheus-hardware-exporter.outcome }}" != "success" ]; then
-            failed_tests+="[prometheus-hardware-exporter](https://github.com/canonical/prometheus-hardware-exporter/actions), "
-          fi
-          if [ "${{ steps.prometheus-juju-exporter.outcome }}" != "success" ]; then
-            failed_tests+="[prometheus-juju-exporter](https://github.com/canonical/prometheus-juju-exporter/actions), "
-          fi
-          if [ "${{ steps.prometheus-juju-backup-all-exporter.outcome }}" != "success" ]; then
-            failed_tests+="[prometheus-juju-backup-all-exporter](https://github.com/canonical/prometheus-juju-backup-all-exporter/actions), "
-          fi
-          if [ "${{ steps.snap-tempest.outcome }}" != "success" ]; then
-            failed_tests+="[snap-tempest](https://github.com/canonical/snap-tempest/actions), "
-          fi
-          if [ "${{ steps.charmed-openstack-upgrader.outcome }}" != "success" ]; then
-            failed_tests+="[charmed-openstack-upgrader](https://github.com/canonical/charmed-openstack-upgrader/actions), "
+          if [ "${{ steps.dispatched-tests.outcome }}" != "success" ]; then
+            failed_tests+="[${{ matrix.charm }}](https://github.com/canonical/${{ matrix.charm }}/actions), "
           fi
           # Set the output variable to pass the failed tests to the next job
           echo "failed_tests=$failed_tests" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -104,11 +104,13 @@ jobs:
 
       - name: Collect failed tests
         id: collect-failed-tests
+        env:
+          WORKFLOW_URL: ${{ steps.dispatched-test.outputs.workflow_url }}
         if: ${{ failure() }}
         run: |
           failed_tests=""
           if [ "${{ steps.dispatched-tests.outcome }}" != "success" ]; then
-            failed_tests+="[${{ matrix.repo }}](https://github.com/canonical/${{ matrix.repo }}/actions), "
+            failed_tests+="[${{ matrix.repo }}]($WORKFLOW_URL), "
           fi
           # Set the output variable to pass the failed tests to the next job
           echo "failed_tests=$failed_tests" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -14,6 +14,7 @@ jobs:
       failed_tests: ${{ steps.collect-failed-tests.outputs.failed_tests }}
     strategy:
       max-parallel: 3
+      fail-fast: false
       matrix:
         include:
           - repo: charm-advanced-routing

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -125,7 +125,7 @@ jobs:
 
   notify:
     needs: weekly-tests
-    if: always()  # these needs to be run always
+    if: always()  # these need to be run always
     name: Notify SolEng with results
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -40,7 +40,7 @@ jobs:
             branch: master
           - repo: charm-juju-local
             workflow_file_name: check.yaml
-            branch: main
+            branch: master
           - repo: charm-kubernetes-service-checks
             workflow_file_name: check.yaml
             branch: master
@@ -81,7 +81,7 @@ jobs:
             workflow_file_name: pr.yaml
             branch: main
           - repo: prometheus-juju-backup-all-exporter
-            workflow_file_name: pr.yaml
+            workflow_file_name: check.yaml
             branch: main
           - repo: snap-tempest
             workflow_file_name: pr.yaml

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The configuration description:
  - `branch` name of branch from which tests should be executed, e.g. main
 
 Jobs are running in parallel with the maximum number of concurrency defined by the `max-parallel` strategy parameter,
-we can to control how many jobs can be run simultaneously using this parameter.
-This is important for us, since we don't want to allow all jobs to run at the same time, because some of them are
-running on top of self-hosted runners, and we can hit quota limits.
+we can control how many jobs can be run simultaneously using this parameter.
+This is important for us because we don't want to allow all jobs to run simultaneously. Some of them are
+running on top of self-hosted runners, and we could hit quota limits.
 
-The result of each run is collected and sent via MM bot to our channel as notifications.
+The results of each run are collected, aggregated, and then sent via MM bot to our channel as notifications.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The configuration description:
  - `workflow_file_name` is name of workflow file which should be triggered, e.g. check.yaml
  - `branch` name of branch from which tests should be executed, e.g. main
 
-All jobs are run in parallel with the maximum number of concurency defined by the `max-parallel` strategy parameter,
+Jobs are running in parallel with the maximum number of concurrency defined by the `max-parallel` strategy parameter,
 we can to control how many jobs can be run simultaneously using this parameter.
 This is important for us, since we don't want to allow all jobs to run at the same time, because some of them are
 running on top of self-hosted runners, and we can hit quota limits.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Repo for automating tasks for Solutions Engineering Team.
 
 The weekly_tests workflow lists all repos on GitHub maintained by the Solutions Engineering Team, and the job for dispatching test on top of those repos remotely.
 The configuration description:
- - `repo` is name repo in canonical organization, e.g. https://github.com/canonical/charm-apt-mirror/
+ - `repo` is the name of a repository in canonical organization, e.g. charm-apt-mirror
  - `workflow_file_name` is name of workflow file which should be triggered, e.g. check.yaml
  - `branch` name of branch from which tests should be executed, e.g. main
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # solutions-engineering-automation
 Repo for automating tasks for Solutions Engineering Team.
+
+
+## How it works
+
+The weekly_tests workflow lists all repos on GitHub maintained by the Solutions Engineering Team, and the job for dispatching test on top of those repos remotely.
+The configuration description:
+ - `repo` is name repo in canonical organization, e.g. https://github.com/canonical/charm-apt-mirror/
+ - `workflow_file_name` is name of workflow file which should be triggered, e.g. check.yaml
+ - `branch` name of branch from which tests should be executed, e.g. main
+
+All jobs are run in parallel with the maximum number of concurency defined by the `max-parallel` strategy parameter,
+we can to control how many jobs can be run simultaneously using this parameter.
+This is important for us, since we don't want to allow all jobs to run at the same time, because some of them are
+running on top of self-hosted runners, and we can hit quota limits.
+
+The result of each run is collected and sent via MM bot to our channel as notifications.


### PR DESCRIPTION
The small self-hosted runners were removed and since we do not need to run this workflow on self-hosted runner, I'll change to GitHub runners. 

I also change to use matrix strategy with [max-parallel](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#defining-the-maximum-number-of-concurrent-jobs) parameter set to 3 and adding also documentation about it. However this required to use artifacts to store results, so I update also that with new message.

run example: [23668147146](https://github.com/canonical/solutions-engineering-automation/actions/runs/8633904492/job/23668147146)
message example:
![Screenshot from 2024-04-10 17-42-34](https://github.com/canonical/solutions-engineering-automation/assets/34167657/6dfb135e-1c28-4c10-82f6-eef9c0ff2283)
