### PR TITLE
Add missing projects to weekly test

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -17,7 +17,7 @@ jobs:
         include:
           - repo: charm-advanced-routing
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-apt-mirror
             workflow_file_name: check.yaml
             branch: main
@@ -26,40 +26,40 @@ jobs:
             branch: main
           - repo: charm-duplicity
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-juju-backup-all
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-juju-local
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-kubernetes-service-checks
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-local-users
             workflow_file_name: check.yaml
             branch: main
           - repo: charm-logrotated
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-nginx
             workflow_file_name: check.yaml
             branch: main
           - repo: charm-nrpe
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-openstack-service-checks
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-prometheus-blackbox-exporter
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-prometheus-juju-exporter
             workflow_file_name: check.yaml
             branch: main
           - repo: charm-prometheus-libvirt-exporter
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-simple-streams
             workflow_file_name: check.yaml
             branch: main

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -15,9 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - repo: bootstack-actions
-            workflow_file_name: pull-request.yaml
-            branch: main
           - repo: charm-advanced-routing
             workflow_file_name: check.yaml
             branch: master
@@ -68,25 +65,22 @@ jobs:
             branch: main
           - repo: charm-storage-connector
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-sysconfig
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charm-userdir-ldap
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: charmed-openstack-upgrader
             workflow_file_name: check.yaml
             branch: main
           - repo: hardware-observer-operator
             workflow_file_name: check.yaml
-            branch: master
+            branch: main
           - repo: hardware-observer-operator
             workflow_file_name: cos_integration.yaml
-            branch: master
-          - repo: layer-beats-base 
-            workflow_file_name: ci.yaml
-            branch: master
+            branch: main
           - repo: openstack-exporter-operator 
             workflow_file_name: pull-request.yaml
             branch: main
@@ -101,6 +95,12 @@ jobs:
             branch: main
           - repo: snap-tempest
             workflow_file_name: pr.yaml
+            branch: main
+          - repo: juju-lint
+            workflow_file_name: check.yaml
+            branch: main
+          - repo: juju-backup-all
+            workflow_file_name: check.yaml
             branch: main
 
     steps:

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -15,6 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - repo: bootstack-actions
+            workflow_file_name: pull-request.yaml
+            branch: main
           - repo: charm-advanced-routing
             workflow_file_name: check.yaml
             branch: master
@@ -26,12 +29,6 @@ jobs:
             branch: main
           - repo: charm-duplicity
             workflow_file_name: check.yaml
-            branch: master
-          - repo: hardware-observer-operator
-            workflow_file_name: check.yaml
-            branch: master
-          - repo: hardware-observer-operator
-            workflow_file_name: cos_integration.yaml
             branch: master
           - repo: charm-juju-backup-all
             workflow_file_name: check.yaml
@@ -51,12 +48,18 @@ jobs:
           - repo: charm-nginx
             workflow_file_name: check.yaml
             branch: main
+          - repo: charm-nrpe
+            workflow_file_name: check.yaml
+            branch: master
           - repo: charm-openstack-service-checks
             workflow_file_name: check.yaml
             branch: master
           - repo: charm-prometheus-blackbox-exporter
             workflow_file_name: check.yaml
             branch: master
+          - repo: charm-prometheus-juju-exporter
+            workflow_file_name: check.yaml
+            branch: main
           - repo: charm-prometheus-libvirt-exporter
             workflow_file_name: check.yaml
             branch: master
@@ -72,20 +75,32 @@ jobs:
           - repo: charm-userdir-ldap
             workflow_file_name: check.yaml
             branch: master
+          - repo: charmed-openstack-upgrader
+            workflow_file_name: check.yaml
+            branch: main
+          - repo: hardware-observer-operator
+            workflow_file_name: check.yaml
+            branch: master
+          - repo: hardware-observer-operator
+            workflow_file_name: cos_integration.yaml
+            branch: master
+          - repo: layer-beats-base 
+            workflow_file_name: ci.yaml
+            branch: master
+          - repo: openstack-exporter-operator 
+            workflow_file_name: pull-request.yaml
+            branch: main
           - repo: prometheus-hardware-exporter
+            workflow_file_name: check.yaml
+            branch: main
+          - repo: prometheus-juju-backup-all-exporter
             workflow_file_name: check.yaml
             branch: main
           - repo: prometheus-juju-exporter
             workflow_file_name: pr.yaml
             branch: main
-          - repo: prometheus-juju-backup-all-exporter
-            workflow_file_name: check.yaml
-            branch: main
           - repo: snap-tempest
             workflow_file_name: pr.yaml
-            branch: main
-          - repo: charmed-openstack-upgrader
-            workflow_file_name: check.yaml
             branch: main
 
     steps:


### PR DESCRIPTION
Add missing projects to weekly test, reordered some tests to match [the team repositories](https://github.com/orgs/canonical/teams/soleng-reviewers/repositories?page=1). Update all branch names to main. Please don't merge until [39](https://github.com/canonical/juju-backup-all/pull/39) and [BSENG-2322](https://warthogs.atlassian.net/browse/BSENG-2322) are completed.


[BSENG-2322]: https://warthogs.atlassian.net/browse/BSENG-2322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ