### PR TITLE
Update multi-line usage for results

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -139,7 +139,11 @@ jobs:
            sudo apt install jq -y
       - name: Concatenate results
         run: |
-           echo "results=$(jq -s '.[] | ["- [\(.repo) (\(.branch), \(.workflow_file_name))](\(.workflow_url)) \(if .conclusion == "success" then ":gh-success-octicon-checkcirclefillicon:" else ":gh-failure-octicon-xcirclefillicon:" end)"]' result-*.json | jq -r 'join("\n")')" >> "$GITHUB_ENV"
+          {
+           echo 'results<<EOF'
+           jq -s '.[] | ["- [\(.repo) (\(.branch), \(.workflow_file_name))](\(.workflow_url)) \(if .conclusion == "success" then ":gh-success-octicon-checkcirclefillicon:" else ":gh-failure-octicon-xcirclefillicon:" end)"]' result-*.json | jq -r 'join("\n")'
+           echo EOF
+          } >> "$GITHUB_ENV"
       - name: Send the Mattermost Message
         uses: mattermost/action-mattermost-notify@master
         with:


### PR DESCRIPTION
With the [recent change to update the MM action usage](https://github.com/canonical/solutions-engineering-automation/pull/12), the `results` variable is not populated correctly as seen in [this failed action run](https://github.com/canonical/solutions-engineering-automation/actions/runs/8893565754/job/24420030681).

This is because writing an env var to `GITHUB_ENV` requires a different syntax if setting multiple lines as [mentioned in the docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings). This PR makes that change for the `results` env var.