### PR TITLE
fix(terraform): create pr only if workflow files content is different

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -46,7 +46,8 @@ jobs:
         run: |
           terraform plan -no-color \
           -var-file=configs/github.tfvars \
-          -var-file=configs/${{ matrix.repository }}.tfvars
+          -var-file=configs/${{ matrix.repository }}.tfvars \
+          -out ./tf.plan
       - name: Terraform Apply only on merge to main
         if: ${{ github.event_name == 'push' }}
         working-directory: ./terraform-plans
@@ -55,6 +56,4 @@ jobs:
           GITHUB_APP_INSTALLATION_ID: ${{ secrets.SOLENG_APP_INSTALLATION_ID }}
           GITHUB_APP_PEM_FILE: ${{ secrets.SOLENG_APP_PEM_FILE }}
         run: |
-          terraform apply -no-color -auto-approve \
-          -var-file=configs/github.tfvars \
-          -var-file=configs/${{ matrix.repository }}.tfvars
+          terraform apply ./tf.plan -no-color

--- a/terraform-plans/README.md
+++ b/terraform-plans/README.md
@@ -19,3 +19,9 @@ The permissions required for the github application are:
 > This Github Application need to be installed on every repositories we want to manage. Please ask people who has Github Organization permission for help.
 > 
 > For how to create the github application, please check [Creating Github Apps](https://docs.github.com/en/apps/creating-github-apps)
+
+## Issues
+
+### branch_protection
+
+The Terraform Github provider does not support creating a branch protection rule if it does not already exist. Initially, an admin user must manually create the branch protection rule.

--- a/terraform-plans/README.md
+++ b/terraform-plans/README.md
@@ -20,7 +20,7 @@ The permissions required for the github application are:
 > 
 > For how to create the github application, please check [Creating Github Apps](https://docs.github.com/en/apps/creating-github-apps)
 
-## Issues
+## Known limitation
 
 ### branch_protection
 

--- a/terraform-plans/main.tf
+++ b/terraform-plans/main.tf
@@ -32,6 +32,10 @@ output "pr_created" {
   value = module.github_workflow_files.pr_created
 }
 
+output "pr_url" {
+  value = module.github_workflow_files.pr_url
+}
+
 output "changed_files" {
   value = module.github_workflow_files.changed_files
 }

--- a/terraform-plans/main.tf
+++ b/terraform-plans/main.tf
@@ -15,3 +15,7 @@ module "github_workflow_files" {
   branch         = var.branch
   workflow_files = var.workflow_files
 }
+
+output "changed_files" {
+  value = module.github_workflow_files.changed_files
+}

--- a/terraform-plans/main.tf
+++ b/terraform-plans/main.tf
@@ -16,6 +16,22 @@ module "github_workflow_files" {
   workflow_files = var.workflow_files
 }
 
+output "repository" {
+  value = module.github_workflow_files.repository
+}
+
+output "branch" {
+  value = module.github_workflow_files.branch
+}
+
+output "pr_branch" {
+  value = module.github_workflow_files.pr_branch
+}
+
+output "pr_created" {
+  value = module.github_workflow_files.pr_created
+}
+
 output "changed_files" {
   value = module.github_workflow_files.changed_files
 }

--- a/terraform-plans/modules/GitHub/workflows/main.tf
+++ b/terraform-plans/modules/GitHub/workflows/main.tf
@@ -121,3 +121,11 @@ output "pr_branch" {
     github_repository_pull_request.workflows_update_pr
   ]
 }
+
+output "pr_url" {
+  value = length(local.changed_files) > 0 ? "https://github.com/${var.owner}/${var.repo}/pull/${github_repository_pull_request.workflows_update_pr[0].number}" : "No PR created"
+
+  depends_on = [
+    github_repository_pull_request.workflows_update_pr
+  ]
+}

--- a/terraform-plans/modules/GitHub/workflows/main.tf
+++ b/terraform-plans/modules/GitHub/workflows/main.tf
@@ -9,9 +9,8 @@ terraform {
 
 provider "github" {
   owner = var.owner
-  app_auth {} # using environmet variables for auth
+  app_auth {} # using environment variables for auth
 }
-
 
 resource "random_string" "update_uid" {
   length  = 8
@@ -19,31 +18,81 @@ resource "random_string" "update_uid" {
   special = false
 }
 
+locals {
+  repo_files = flatten([
+    for file_key, file_info in var.workflow_files : {
+      repo = var.repository
+      file = file_info.destination
+      source = file_info.source
+    }
+  ])
+}
+
+data "github_repository_file" "files" {
+  for_each = {
+    for item in local.repo_files : "${item.repo}-${item.file}" => item
+  }
+
+  repository = each.value.repo
+  file       = each.value.file
+  branch     = var.branch
+}
+
+locals {
+  repository_files_content = {
+    for file_key, file_info in var.workflow_files : file_info.destination =>
+      try(data.github_repository_file.files["${var.repository}-${file_info.destination}"].content, "")
+  }
+}
+
+locals {
+  changed_files = {
+    for file_key, file_info in var.workflow_files : file_key => file_info
+      if file(file_info.source) != local.repository_files_content[file_info.destination]
+  }
+}
+
 resource "github_branch" "workflows_branch" {
+  count = length(local.changed_files) > 0 ? 1 : 0
+
   repository    = var.repository
   branch        = "${var.pr_branch}-${random_string.update_uid.id}"
   source_branch = var.branch
 }
 
 resource "github_repository_file" "workflows_files" {
-  for_each            = var.workflow_files
+  for_each = local.changed_files
+
   repository          = var.repository
-  branch              = github_branch.workflows_branch.branch
+  branch              = github_branch.workflows_branch[0].branch
   file                = each.value.destination
   content             = file(each.value.source)
   commit_message      = "update ${each.value.destination}"
   overwrite_on_create = true
+
+  depends_on = [github_branch.workflows_branch]
 }
 
 resource "github_repository_pull_request" "workflows_update_pr" {
+  count = length(local.changed_files) > 0 ? 1 : 0
+
   base_repository = var.repository
   base_ref        = var.branch
-  head_ref        = github_branch.workflows_branch.branch
+  head_ref        = github_branch.workflows_branch[0].branch
   title           = var.pr_title
   body            = var.pr_body
 
   depends_on = [
     github_branch.workflows_branch,
     github_repository_file.workflows_files
+  ]
+}
+
+output "changed_files" {
+  description = "Execute result: [repository, branch, changed_files]"
+  value = [
+      var.repository,
+      var.branch,
+      local.changed_files
   ]
 }

--- a/terraform-plans/modules/GitHub/workflows/main.tf
+++ b/terraform-plans/modules/GitHub/workflows/main.tf
@@ -123,7 +123,7 @@ output "pr_branch" {
 }
 
 output "pr_url" {
-  value = length(local.changed_files) > 0 ? "https://github.com/${var.owner}/${var.repo}/pull/${github_repository_pull_request.workflows_update_pr[0].number}" : "No PR created"
+  value = length(local.changed_files) > 0 ? "https://github.com/${var.owner}/${var.repository}/pull/${github_repository_pull_request.workflows_update_pr[0].number}" : "No PR created"
 
   depends_on = [
     github_repository_pull_request.workflows_update_pr

--- a/terraform-plans/modules/GitHub/workflows/main.tf
+++ b/terraform-plans/modules/GitHub/workflows/main.tf
@@ -21,7 +21,6 @@ resource "random_string" "update_uid" {
 locals {
   repo_files = flatten([
     for file_key, file_info in var.workflow_files : {
-      repo = var.repository
       file = file_info.destination
       source = file_info.source
     }
@@ -30,10 +29,10 @@ locals {
 
 data "github_repository_file" "files" {
   for_each = {
-    for item in local.repo_files : "${item.repo}-${item.file}" => item
+    for item in local.repo_files : "${item.file}" => item
   }
 
-  repository = each.value.repo
+  repository = var.repository
   file       = each.value.file
   branch     = var.branch
 }
@@ -41,7 +40,7 @@ data "github_repository_file" "files" {
 locals {
   repository_files_content = {
     for file_key, file_info in var.workflow_files : file_info.destination =>
-      try(data.github_repository_file.files["${var.repository}-${file_info.destination}"].content, "")
+      try(data.github_repository_file.files["${file_info.destination}"].content, "")
   }
 }
 


### PR DESCRIPTION
- Fix: #17
- Add document for branch production rule if it's not exists.
- Update terraform workflow to use plan output instead re-plan when apply.