### PR TITLE
ci: Dropdown for promote.yaml

### DIFF
--- a/terraform-plans/files/github/charm_promote.yaml
+++ b/terraform-plans/files/github/charm_promote.yaml
@@ -1,4 +1,4 @@
-name: Promote charm to other tracks and channels
+name: Promote charm to default track, standard risk levels.
 
 on:
   workflow_dispatch:
@@ -6,9 +6,17 @@ on:
       destination-channel:
         description: 'Destination Channel, e.g. latest/candidate'
         required: true
+        type: choice
+        options:
+          - 'latest/candidate'
+          - 'latest/stable'
       origin-channel:
         description: 'Origin Channel, e.g. latest/edge'
         required: true
+        type: choice
+        options:
+          - 'latest/edge'
+          - 'latest/candidate'
 
 jobs:
   promote-charm:

--- a/terraform-plans/files/github/charm_promote.yaml
+++ b/terraform-plans/files/github/charm_promote.yaml
@@ -3,20 +3,13 @@ name: Promote charm to default track, standard risk levels.
 on:
   workflow_dispatch:
     inputs:
-      destination-channel:
-        description: 'Destination Channel, e.g. latest/candidate'
+      channel-promotion:
+        description: 'Channel Promotion, e.g. latest/edge -> latest/candidate'
         required: true
         type: choice
         options:
-          - 'latest/candidate'
-          - 'latest/stable'
-      origin-channel:
-        description: 'Origin Channel, e.g. latest/edge'
-        required: true
-        type: choice
-        options:
-          - 'latest/edge'
-          - 'latest/candidate'
+          - 'latest/edge -> latest/candidate'
+          - 'latest/candidate -> latest/stable'
 
 jobs:
   promote-charm:
@@ -24,10 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set channels
+        id: set-channels
+        run: |
+          channel_promotion="$${{ github.event.inputs.channel-promotion }}"
+          origin=$(echo "$channel_promotion" | sed 's/ ->.*//')
+          destination=$(echo "$channel_promotion" | sed 's/.* -> //')
+          echo "DESTINATION_CHANNEL=$destination" >> $GITHUB_ENV
+          echo "ORIGIN_CHANNEL=$origin" >> $GITHUB_ENV
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.4.0
         with:
           credentials: $${{ secrets.CHARMHUB_TOKEN }}
           github-token: $${{ secrets.GITHUB_TOKEN }}
-          destination-channel: $${{ github.event.inputs.destination-channel }}
-          origin-channel: $${{ github.event.inputs.origin-channel }}
+          destination-channel: $${{ env.DESTINATION_CHANNEL }}
+          origin-channel: $${{ env.ORIGIN_CHANNEL }}

--- a/terraform-plans/files/github/charm_promote.yaml
+++ b/terraform-plans/files/github/charm_promote.yaml
@@ -21,14 +21,14 @@ jobs:
         id: set-channels
         run: |
           channel_promotion="$${{ github.event.inputs.channel-promotion }}"
-          origin=$(echo "$channel_promotion" | sed 's/ ->.*//')
-          destination=$(echo "$channel_promotion" | sed 's/.* -> //')
-          echo "DESTINATION_CHANNEL=$destination" >> $GITHUB_ENV
-          echo "ORIGIN_CHANNEL=$origin" >> $GITHUB_ENV
+          origin=$(echo "$channel_promotion" | sed 's/\s*->.*//')
+          destination=$(echo "$channel_promotion" | sed 's/.*->\s*//')
+          echo "destination-channel=$destination" >> $GITHUB_OUTPUT
+          echo "origin-channel=$origin" >> $GITHUB_OUTPUT
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.4.0
         with:
           credentials: $${{ secrets.CHARMHUB_TOKEN }}
           github-token: $${{ secrets.GITHUB_TOKEN }}
-          destination-channel: $${{ env.DESTINATION_CHANNEL }}
-          origin-channel: $${{ env.ORIGIN_CHANNEL }}
+          destination-channel: $${{ steps.set-channels.outputs.destination-channel }}
+          origin-channel: $${{ steps.set-channels.outputs.origin-channel }}

--- a/terraform-plans/files/github/snap_promote.yaml
+++ b/terraform-plans/files/github/snap_promote.yaml
@@ -3,20 +3,13 @@ name: Promote snap to default track, standard risk levels.
 on:
   workflow_dispatch:
     inputs:
-      destination-channel:
-        description: 'Destination Channel, e.g. latest/candidate'
+      channel-promotion:
+        description: 'Channel Promotion, e.g. latest/edge -> latest/candidate'
         required: true
         type: choice
         options:
-          - 'latest/candidate'
-          - 'latest/stable'
-      origin-channel:
-        description: 'Origin Channel, e.g. latest/edge'
-        required: true
-        type: choice
-        options:
-          - 'latest/edge'
-          - 'latest/candidate'
+          - 'latest/edge -> latest/candidate'
+          - 'latest/candidate -> latest/stable'
 
 jobs:
   promote-snap:
@@ -29,6 +22,14 @@ jobs:
       - name: Get snap name
         id: snap
         run: echo "name=$(awk '/^name:/ {print $2}' snap/snapcraft.yaml)" >> "$GITHUB_OUTPUT"
+      - name: Set channels
+        id: set-channels
+        run: |
+          channel_promotion="$${{ github.event.inputs.channel-promotion }}"
+          origin=$(echo "$channel_promotion" | sed 's/\s*->.*//')
+          destination=$(echo "$channel_promotion" | sed 's/.*->\s*//')
+          echo "destination-channel=$destination" >> $GITHUB_OUTPUT
+          echo "origin-channel=$origin" >> $GITHUB_OUTPUT
       - name: Snapcraft promote snap
         env:
           SNAPCRAFT_STORE_CREDENTIALS: $${{ secrets.STORE_LOGIN }}
@@ -38,5 +39,5 @@ jobs:
           #       refuse to non-interactively promote a snap from the edge
           #       channel if it is done without any branch qualifiers
           yes | snapcraft promote $${{ steps.snap.outputs.name }}  \
-          --from-channel $${{ github.event.inputs.origin-channel }} \
-          --to-channel $${{ github.event.inputs.destination-channel }}
+          --from-channel $${{ steps.set-channels.outputs.origin-channel }} \
+          --to-channel $${{ steps.set-channels.outputs.destination-channel }}

--- a/terraform-plans/files/github/snap_promote.yaml
+++ b/terraform-plans/files/github/snap_promote.yaml
@@ -1,4 +1,4 @@
-name: Promote snap to other tracks and channels
+name: Promote snap to default track, standard risk levels.
 
 on:
   workflow_dispatch:
@@ -6,9 +6,17 @@ on:
       destination-channel:
         description: 'Destination Channel, e.g. latest/candidate'
         required: true
+        type: choice
+        options:
+          - 'latest/candidate'
+          - 'latest/stable'
       origin-channel:
         description: 'Origin Channel, e.g. latest/edge'
         required: true
+        type: choice
+        options:
+          - 'latest/edge'
+          - 'latest/candidate'
 
 jobs:
   promote-snap:


### PR DESCRIPTION
- Provide default track and risk levels as dropdown in promote.yaml

(planned but not in scope for this PR) - For some projects need to release to different track/risk-levels, we provide another customized file instead using standard one.