### PR TITLE
Fix codeowners file

### DIFF
--- a/terraform-plans/files/github/CODEOWNERS
+++ b/terraform-plans/files/github/CODEOWNERS
@@ -7,4 +7,4 @@
 # These owners will be the default owners for everything in the repo. Unless a
 # later match takes precedence, @canonical/soleng-reviewers will be requested for
 # review when someone opens a pull request.
-	@canonical/soleng-reviewers
+*    @canonical/soleng-reviewers


### PR DESCRIPTION
The leading `*` (to say all files have this owner) was somehow lost during the migration to terraform managed files.