### PR TITLE
Simplify weekly tests job matrix

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -14,94 +14,45 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
+        repo:
+          - charm-advanced-routing
+          - charm-apt-mirror
+          - charm-cloudsupport
+          - charm-duplicity
+          - charm-juju-backup-all
+          - charm-juju-local
+          - charm-kubernetes-service-checks
+          - charm-local-users
+          - charm-logrotated
+          - charm-nginx
+          - charm-nrpe
+          - charm-openstack-service-checks
+          - charm-prometheus-blackbox-exporter
+          - charm-prometheus-juju-exporter
+          - charm-prometheus-libvirt-exporter
+          - charm-simple-streams
+          - charm-storage-connector
+          - charm-sysconfig
+          - charm-userdir-ldap
+          - charmed-openstack-upgrader
+          - juju-backup-all
+          - juju-lint
+          - openstack-exporter-operator
+          - prometheus-hardware-exporter
+          - prometheus-juju-backup-all-exporter
+        workflow_file_name:
+          - check.yaml
         include:
-          - repo: charm-advanced-routing
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-apt-mirror
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-cloudsupport
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-duplicity
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-juju-backup-all
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-juju-local
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-kubernetes-service-checks
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-local-users
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-logrotated
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-nginx
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-nrpe
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-openstack-service-checks
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-prometheus-blackbox-exporter
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-prometheus-juju-exporter
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-prometheus-libvirt-exporter
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-simple-streams
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-storage-connector
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-sysconfig
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charm-userdir-ldap
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: charmed-openstack-upgrader
-            workflow_file_name: check.yaml
-            branch: main
           - repo: hardware-observer-operator
             workflow_file_name: check.yaml
-            branch: main
           - repo: hardware-observer-operator
             workflow_file_name: cos_integration.yaml
-            branch: main
-          - repo: openstack-exporter-operator 
+          - repo: openstack-exporter-operator
             workflow_file_name: pull-request.yaml
-            branch: main
-          - repo: prometheus-hardware-exporter
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: prometheus-juju-backup-all-exporter
-            workflow_file_name: check.yaml
-            branch: main
           - repo: prometheus-juju-exporter
             workflow_file_name: pr.yaml
-            branch: main
           - repo: snap-tempest
             workflow_file_name: pr.yaml
-            branch: main
-          - repo: juju-lint
-            workflow_file_name: check.yaml
-            branch: main
-          - repo: juju-backup-all
-            workflow_file_name: check.yaml
-            branch: main
 
     steps:
       - name: Running ${{ matrix.workflow_file_name }} tests for ${{ matrix.repo }}
@@ -112,7 +63,7 @@ jobs:
           repo: ${{ matrix.repo }}
           github_token: ${{ secrets.GHA_WORKFLOW_TRIGGER }}
           workflow_file_name: ${{ matrix.workflow_file_name }}
-          ref: ${{ matrix.branch }}
+          ref: main
           wait_interval: 60
 
       - name: Collect result
@@ -123,7 +74,7 @@ jobs:
               {
                   "job-index": "${{ strategy.job-index }}",
                   "repo": "${{ matrix.repo }}",
-                  "branch": "${{ matrix.branch }}",
+                  "branch": "main",
                   "workflow_file_name":"${{ matrix.workflow_file_name }}",
                   "conclusion": "${{ steps.dispatched-tests.outcome }}",
                   "workflow_url": "${{ steps.dispatched-tests.outputs.workflow_url }}"


### PR DESCRIPTION
- Remove branch variable because all are using branch main now.
- Most are using check.yaml for the workflow file, so use that as the default, and add include entries for outliers.

Fixes: #7