### PR TITLE
Fix openstack-exporter-operator duplicated check

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -37,7 +37,6 @@ jobs:
           - charmed-openstack-upgrader
           - juju-backup-all
           - juju-lint
-          - openstack-exporter-operator
           - prometheus-hardware-exporter
           - prometheus-juju-backup-all-exporter
         workflow_file_name:


### PR DESCRIPTION
openstack-exporter-operator has a custom CI file (pull-request.yaml). So it needs to be removed from the main matrix list for weekly tests, otherwise the CI will try running it with check.yaml too.