### PR TITLE
Add config for managing charm-local-users

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -24,6 +24,7 @@ jobs:
             # The naming of the files should be $REPO_$BRANCH.tfvars
             - charmed-openstack-upgrader_main
             - hardware-observer-operator_main
+            - charm-local-users_main
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -1,0 +1,27 @@
+repository             = "charm-local-users"
+repository_description = "A subordinate charm for creating and managing local user accounts and groups on principal units."
+branch                 = "main"
+workflow_files = {
+  codeowners = {
+    source      = "./templates/github/CODEOWNERS.tftpl"
+    destination = ".github/CODEOWNERS"
+    variables   = {}
+  }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    variables   = {}
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    variables   = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    variables = {
+      branch = "main"
+    }
+  }
+}

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -1,0 +1,82 @@
+# This file is centrally managed as a template file in https://github.com/canonical/solutions-engineering-automation
+# To update the file:
+# - Edit it in the canonical/solutions-engineering-automation repository.
+# - Open a PR with the changes.
+# - When the PR merges, the soleng-terraform bot will open a PR to the target repositories with the changes.
+name: Tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master, main]
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+
+concurrency:
+  group: $${{ github.workflow }}-$${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-unit:
+    uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.10"]
+    with:
+      python-version: $${{ matrix.python-version }}
+      tox-version: "<4"
+
+  func:
+    needs: lint-unit
+    name: functional tests
+    runs-on: $${{ matrix.architecture.runs-on }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        juju-channel: ["3.4/stable"]
+        architecture:
+          - runs-on: [ubuntu-latest]  # github hosted runners are amd64
+            model-constraints: ""
+            # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
+            # We prefer the github runners because they are smaller machines and save resources.
+            # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
+            # - runs-on: [self-hosted, jammy, ARM64]
+          - runs-on: [Ubuntu_ARM64_4C_16G_01]
+            model-constraints: arch=arm64
+    steps:
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Setup Juju environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: "lxd"
+          juju-channel: $${{ matrix.juju-channel }}
+
+      - name: Install latest tox version
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+
+      - name: Show juju information
+        run: |
+          juju version
+          juju controllers | grep Version -A 1 | awk '{print $9}'
+
+      - name: Run tests
+        run: "make functional"
+        env:
+          TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
+          TEST_MODEL_CONSTRAINTS: $${{ matrix.architecture.model-constraints }}


### PR DESCRIPTION
This moves the following files for https://github.com/canonical/charm-local-users under control of this automation repo:

- CODEOWNERS
- workflows/check.yaml
- workflows/promote.yaml
- workflows/release.yaml

It will also apply our standard config to the charm-local-users repository itself.