### PR TITLE
Refactor workflow_files variable

### DIFF
--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -1,26 +1,26 @@
 repository             = "charm-local-users"
 repository_description = "A subordinate charm for creating and managing local user accounts and groups on principal units."
 branch                 = "main"
-workflow_files = {
+templates = {
   codeowners = {
     source      = "./templates/github/CODEOWNERS.tftpl"
     destination = ".github/CODEOWNERS"
-    variables   = {}
+    vars        = {}
   }
   check = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
-    variables   = {}
+    vars        = {}
   }
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    variables   = {}
+    vars        = {}
   }
   release = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
-    variables = {
+    vars      = {
       branch = "main"
     }
   }

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -20,7 +20,7 @@ templates = {
   release = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
-    vars      = {
+    vars        = {
       branch = "main"
     }
   }

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -1,21 +1,21 @@
 repository             = "charmed-openstack-upgrader"
 repository_description = "Automatic upgrade tool for Charmed Openstack"
 branch                 = "main"
-workflow_files = {
+templates = {
   codeowners = {
     source      = "./templates/github/CODEOWNERS.tftpl"
     destination = ".github/CODEOWNERS"
-    variables   = {}
+    vars        = {}
   }
   promote = {
     source      = "./templates/github/snap_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    variables   = {}
+    vars        = {}
   }
   release = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
-    variables = {
+    vars        = {
       branch = "main"
     }
   }

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -1,21 +1,21 @@
 repository             = "hardware-observer-operator"
 branch                 = "main"
 repository_description = "A charm to setup prometheus exporter for IPMI, RedFish and RAID devices from different vendors."
-workflow_files = {
+templates = {
   codeowners = {
     source      = "./templates/github/CODEOWNERS.tftpl"
     destination = ".github/CODEOWNERS"
-    variables   = {}
+    vars        = {}
   }
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    variables   = {}
+    vars        = {}
   }
   release = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
-    variables = {
+    vars        = {
       branch = "main"
     }
   }

--- a/terraform-plans/main.tf
+++ b/terraform-plans/main.tf
@@ -6,34 +6,34 @@ module "github_settings" {
   branch                 = var.branch
 }
 
-module "github_workflow_files" {
-  source         = "./modules/GitHub/workflows"
+module "github_templates" {
+  source         = "./modules/GitHub/templates"
   owner          = var.owner
   repository     = var.repository
   branch         = var.branch
-  workflow_files = var.workflow_files
+  templates = var.templates
 }
 
 output "repository" {
-  value = module.github_workflow_files.repository
+  value = module.github_templates.repository
 }
 
 output "branch" {
-  value = module.github_workflow_files.branch
+  value = module.github_templates.branch
 }
 
 output "pr_branch" {
-  value = module.github_workflow_files.pr_branch
+  value = module.github_templates.pr_branch
 }
 
 output "pr_created" {
-  value = module.github_workflow_files.pr_created
+  value = module.github_templates.pr_created
 }
 
 output "pr_url" {
-  value = module.github_workflow_files.pr_url
+  value = module.github_templates.pr_url
 }
 
 output "changed_files" {
-  value = module.github_workflow_files.changed_files
+  value = module.github_templates.changed_files
 }

--- a/terraform-plans/main.tf
+++ b/terraform-plans/main.tf
@@ -11,7 +11,7 @@ module "github_templates" {
   owner          = var.owner
   repository     = var.repository
   branch         = var.branch
-  templates = var.templates
+  templates      = var.templates
 }
 
 output "repository" {

--- a/terraform-plans/modules/GitHub/settings/main.tf
+++ b/terraform-plans/modules/GitHub/settings/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 provider "github" {
   owner = var.owner
-  app_auth {} # using environmet variables for auth
+  app_auth {} # using environment variables for auth
 }
 
 resource "github_repository" "repo" {

--- a/terraform-plans/modules/GitHub/templates/main.tf
+++ b/terraform-plans/modules/GitHub/templates/main.tf
@@ -19,10 +19,10 @@ resource "random_string" "update_uid" {
   special = false
 }
 
-# Flatten the repository and file information into a single list of maps based on the workflow_files variable
+# Flatten the repository and file information into a single list of maps based on the templates variable
 locals {
   repo_files = flatten([
-    for file_key, file_info in var.workflow_files : {
+    for file_key, file_info in var.templates : {
       file   = file_info.destination
       source = file_info.source
     }
@@ -43,7 +43,7 @@ data "github_repository_file" "files" {
 # Store the fetched content in a local variable, defaulting to an empty string if the file does not exist
 locals {
   repository_files_content = {
-    for file_key, file_info in var.workflow_files : file_info.destination =>
+    for file_key, file_info in var.templates : file_info.destination =>
     try(data.github_repository_file.files["${file_info.destination}"].content, "")
   }
 }
@@ -51,13 +51,13 @@ locals {
 # Compare the fetched content with the local content to create a map of changed files
 locals {
   changed_files = {
-    for file_key, file_info in var.workflow_files : file_key => file_info
-    if templatefile(file_info.source, { vars = file_info.variables }) != local.repository_files_content[file_info.destination]
+    for file_key, file_info in var.templates : file_key => file_info
+    if templatefile(file_info.source, file_info.vars) != local.repository_files_content[file_info.destination]
   }
 }
 
 # Create a new branch only if there are changed files
-resource "github_branch" "workflows_branch" {
+resource "github_branch" "managed_files_branch" {
   count = length(local.changed_files) > 0 ? 1 : 0
 
   repository    = var.repository
@@ -66,32 +66,32 @@ resource "github_branch" "workflows_branch" {
 }
 
 # Create or update files in the repository only if they have changed
-resource "github_repository_file" "workflows_files" {
+resource "github_repository_file" "managed_files" {
   for_each = local.changed_files
 
   repository          = var.repository
-  branch              = github_branch.workflows_branch[0].branch
+  branch              = github_branch.managed_files_branch[0].branch
   file                = each.value.destination
-  content             = templatefile(each.value.source, { vars = each.value.variables })
+  content             = templatefile(each.value.source, each.value.vars)
   commit_message      = "update ${each.value.destination}"
   overwrite_on_create = true
 
-  depends_on = [github_branch.workflows_branch]
+  depends_on = [github_branch.managed_files_branch]
 }
 
 # Create a pull request only if there are changed files
-resource "github_repository_pull_request" "workflows_update_pr" {
+resource "github_repository_pull_request" "managed_files_update_pr" {
   count = length(local.changed_files) > 0 ? 1 : 0
 
   base_repository = var.repository
   base_ref        = var.branch
-  head_ref        = github_branch.workflows_branch[0].branch
+  head_ref        = github_branch.managed_files_branch[0].branch
   title           = var.pr_title
   body            = var.pr_body
 
   depends_on = [
-    github_branch.workflows_branch,
-    github_repository_file.workflows_files
+    github_branch.managed_files_branch,
+    github_repository_file.managed_files
   ]
 }
 
@@ -115,17 +115,17 @@ output "pr_created" {
 
 # Output the PR branch if PR was created
 output "pr_branch" {
-  value = length(local.changed_files) > 0 ? github_repository_pull_request.workflows_update_pr[0].head_ref : "No PR created"
+  value = length(local.changed_files) > 0 ? github_repository_pull_request.managed_files_update_pr[0].head_ref : "No PR created"
 
   depends_on = [
-    github_repository_pull_request.workflows_update_pr
+    github_repository_pull_request.managed_files_update_pr
   ]
 }
 
 output "pr_url" {
-  value = length(local.changed_files) > 0 ? "https://github.com/${var.owner}/${var.repository}/pull/${github_repository_pull_request.workflows_update_pr[0].number}" : "No PR created"
+  value = length(local.changed_files) > 0 ? "https://github.com/${var.owner}/${var.repository}/pull/${github_repository_pull_request.managed_files_update_pr[0].number}" : "No PR created"
 
   depends_on = [
-    github_repository_pull_request.workflows_update_pr
+    github_repository_pull_request.managed_files_update_pr
   ]
 }

--- a/terraform-plans/modules/GitHub/templates/variables.tf
+++ b/terraform-plans/modules/GitHub/templates/variables.tf
@@ -17,26 +17,30 @@ variable "branch" {
 variable "pr_branch" {
   type        = string
   description = "Pull request branch name."
-  default     = "chore/update-workflows"
+  default     = "chore/update-managed-files"
 }
 
 variable "pr_title" {
   type        = string
   description = "Pull request title."
-  default     = "Update workflow files"
+  default     = "Update centrally managed files"
 }
 
 variable "pr_body" {
   type        = string
   description = "Pull request body message."
-  default     = "This is an automated pull request to update workflow files from https://github.com/canonical/solutions-engineering-automation."
+  default     = "This is an automated pull request from https://github.com/canonical/solutions-engineering-automation to update centrally managed files."
 }
 
-variable "workflow_files" {
+variable "templates" {
   type = map(object({
+    # Path to the template file in this repository.
     source      = string
+    # Path to the target file in the target repository.
     destination = string
-    variables   = map(string)
+    # Variables used in the template,
+    # expected to be variables as passed as the second argument to `templatefile()`.
+    vars        = any
   }))
-  description = "GitHub workflow file. The source is the file path of the template file."
+  description = "Files to be templated into the target GitHub repository."
 }

--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -7,7 +7,7 @@ name: Release to Edge
 
 on:
   push:
-    branches: [ ${vars.branch} ]
+    branches: [ ${branch} ]
   release:
     types: [ published ]
 

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -7,7 +7,7 @@ name: Publish snap
 
 on:
   push:
-    branches: [ ${vars.branch} ]
+    branches: [ ${branch} ]
   release:
     types: [ published ]
 

--- a/terraform-plans/variables.tf
+++ b/terraform-plans/variables.tf
@@ -19,11 +19,15 @@ variable "branch" {
   default     = "main"
 }
 
-variable "workflow_files" {
+variable "templates" {
   type = map(object({
+    # Path to the template file in this repository.
     source      = string
+    # Path to the target file in the target repository.
     destination = string
-    variables   = map(string)
+    # Variables used in the template,
+    # expected to be variables as passed as the second argument to `templatefile()`.
+    vars        = any
   }))
-  description = "GitHub workflow file. The source is the file path of the template file."
+  description = "Files to be templated into the target GitHub repository."
 }


### PR DESCRIPTION
Rename workflow_files to templates:
This makes it clearer that these are any files that are centrally managed via templates from this repository. It's not just workflow files (precedent being CODEOWNERS file).

Change workflow_files.variables type and name:
- type `any` will be required if we want template variables of other types - for example a list of architectures to run on (useful for multiarch releases coming soon)
- vars name is more consistent with the templatefile function args
- also reduce a level of nesting (pass this directly to the template file function, and access the variables directly in the template instead of vars.name)