### PR TITLE
Add config for charmed-openstack-exporter-snap

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -25,6 +25,7 @@ jobs:
             - charmed-openstack-upgrader_main
             - hardware-observer-operator_main
             - charm-local-users_main
+            - charmed-openstack-exporter-snap_main
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -1,0 +1,23 @@
+repository             = "charmed-openstack-exporter-snap"
+repository_description = "Snap package for the OpenStack exporter"
+branch                 = "main"
+workflow_files = {
+  codeowners = {
+    source      = "./templates/github/CODEOWNERS.tftpl"
+    destination = ".github/CODEOWNERS"
+    variables   = {}
+  }
+  promote = {
+    source      = "./templates/github/snap_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    variables   = {}
+  }
+  release = {
+    source      = "./templates/github/snap_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    variables = {
+      branch = "main"
+      include_check_job = false
+    }
+  }
+}

--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -10,6 +10,7 @@ on:
     branches: [ ${branch} ]
   release:
     types: [ published ]
+  workflow_dispatch:
 
 jobs:
   check:

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -10,15 +10,19 @@ on:
     branches: [ ${branch} ]
   release:
     types: [ published ]
+  workflow_dispatch:
 
 jobs:
+{{ if include_check_job }}
   check:
     uses: ./.github/workflows/check.yaml
     secrets: inherit
-
+{{ endif }}
   release:
     runs-on: ubuntu-latest
+{{ if include_check_job }}
     needs: check
+{{ endif }}
     outputs:
       snap: $${{ steps.build.outputs.snap }}
     steps:


### PR DESCRIPTION
This moves the following files for https://github.com/canonical/charmed-openstack-exporter-snap under control of this automation repo:

- CODEOWNERS
- workflows/promote.yaml
- workflows/release.yaml

It will also apply our standard config to the
charmed-openstack-exporter-snap repository itself.

Additional features:
- workflow_dispatch for release
- choose to include the check or not for release