### PR TITLE
Add support for arm64 builds for charm-prometheus-libvirt-exporter

### DIFF
--- a/terraform-plans/configs/charm-prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-openstack-exporter_main.tfvars
@@ -1,0 +1,33 @@
+repository             = "charm-prometheus-libvirt-exporter"
+repository_description = "A charm that provides per-domain metrics related to CPU, memory, disk and network usage using libvirt exporter."
+branch                 = "main"
+templates = {
+  codeowners = {
+    source      = "./templates/github/CODEOWNERS.tftpl"
+    destination = ".github/CODEOWNERS"
+    vars        = {}
+  }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars        = {}
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars        = {
+      branch = "main",
+      # github hosted runners are amd64
+      # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
+      # We prefer the github runners because they are smaller machines and save resources.
+      # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
+      # - runs-on: [self-hosted, jammy, ARM64]
+      runs_on = "[[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]",
+    }
+  }
+}


### PR DESCRIPTION
Update charm-prometheus-libvirt-exporter to use centralize managed files.