### PR TITLE
Add userdir-ldap to automation

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -25,6 +25,7 @@ jobs:
             - charmed-openstack-upgrader_main
             - hardware-observer-operator_main
             - charm-local-users_main
+            - charm-userdir-ldap_main
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -1,0 +1,28 @@
+repository             = "charm-userdir-ldap"
+repository_description = "A charm to install and configured userdir-ldap"
+branch                 = "main"
+templates = {
+  codeowners = {
+    source      = "./templates/github/CODEOWNERS.tftpl"
+    destination = ".github/CODEOWNERS"
+    vars        = {}
+  }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars        = {}
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars        = {
+      branch = "main",
+      runs_on = "[ubuntu-latest]",
+    }
+  }
+}

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [master, main]
+    branches: [main]
     paths-ignore:
       - "**.md"
       - "**.rst"
@@ -28,26 +28,18 @@ jobs:
         python-version: ["3.8", "3.10"]
     with:
       python-version: $${{ matrix.python-version }}
-      tox-version: "<4"
 
   func:
     needs: lint-unit
     name: functional tests
-    runs-on: $${{ matrix.architecture.runs-on }}
+    runs-on: $${{ matrix.runs-on }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ["3.4/stable"]
-        architecture:
-          - runs-on: [ubuntu-latest]  # github hosted runners are amd64
-            model-constraints: ""
-            # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
-            # We prefer the github runners because they are smaller machines and save resources.
-            # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
-            # - runs-on: [self-hosted, jammy, ARM64]
-          - runs-on: [Ubuntu_ARM64_4C_16G_01]
-            model-constraints: arch=arm64
+        runs-on:
+          - [ubuntu-latest]  # github hosted runners are amd64
+          - ['Ubuntu_ARM64_4C_16G_01']
     steps:
 
       - uses: actions/checkout@v4
@@ -63,21 +55,22 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: "lxd"
-          juju-channel: $${{ matrix.juju-channel }}
+          juju-channel: "3.4/stable"
           charmcraft-channel: "2.x/stable"
-
-      - name: Install latest tox version
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
 
       - name: Show juju information
         run: |
           juju version
           juju controllers | grep Version -A 1 | awk '{print $9}'
 
+        # this is used by zaza in the functional tests
+      - name: Set zaza juju model constraints for architecture
+        run: |
+          if [ "$(uname -m)" = "aarch64" ]; then
+            echo "TEST_MODEL_CONSTRAINTS=arch=arm64" >> "$GITHUB_ENV"
+          fi
+
       - name: Run tests
         run: "make functional"
         env:
           TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
-          TEST_MODEL_CONSTRAINTS: $${{ matrix.architecture.model-constraints }}

--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
         # revision is latest main at time of writing; using because it contains a fix to https://github.com/canonical/setup-lxd/issues/19


### PR DESCRIPTION
This makes some changes to the templates that will affect other charms too:

- unpin tox-version for lint; all our lints should work with tox 4 now
- remove step to install latest tox version; the actions-operator action does this for us
- move model-constraints from matrix; we can dynamically derive this value from the environment
- checkout with submodules for charm relesae - some charms have submodules
