### PR TITLE
Fix the release file for charms

### DIFF
--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: ${runs_on}
+        runs-on: [${runs_on}]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- currently the file is broken because it's missing brackets

E.g: [0](https://github.com/canonical/hardware-observer-operator/actions/runs/10497388141/workflow)