### PR TITLE
Fix runs_on for hardware-observer release.yaml

### DIFF
--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -16,7 +16,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "ubuntu-latest",
+      runs_on = "[[ubuntu-latest]]",
     }
   }
 }


### PR DESCRIPTION
It was a typo; update it to match the others.