### PR TITLE
Pin all workflows to explicitly run on Jammy

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   terraform:
     name: Run Terraform
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   weekly-tests:
     name: Run weekly tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 1440
     strategy:
       max-parallel: 3
@@ -89,7 +89,7 @@ jobs:
     needs: weekly-tests
     if: always()  # always send the summary to mattermost
     name: Notify SolEng with results
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -11,7 +11,7 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
       test_commands = "['make functional']",
     }
   }
@@ -24,7 +24,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
     }
   }
 }

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -11,7 +11,7 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
       test_commands = "['FUNC_ARGS=\"--series focal\" make functional', 'FUNC_ARGS=\"--series jammy\" make functional']",
     }
   }
@@ -24,7 +24,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
     }
   }
 }

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -11,7 +11,7 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
       test_commands = "['make functional']",
     }
   }
@@ -24,7 +24,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
     }
   }
 }

--- a/terraform-plans/configs/charm-kubernetes-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-kubernetes-service-checks_main.tfvars
@@ -24,7 +24,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
     }
   }
 }

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -16,7 +16,7 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
-      runs_on = "[[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['make functional']",
     }
   }
@@ -32,7 +32,7 @@ templates = {
       # github hosted runners are amd64
       # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
       # We prefer the github runners because they are smaller machines and save resources.
-      runs_on = "[[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
     }
   }
 }

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -16,7 +16,7 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
-      runs_on = "[[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['make functional']",
     }
   }
@@ -29,7 +29,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -16,7 +16,7 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
-      runs_on = "[[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['make functional']",
     }
   }
@@ -32,7 +32,7 @@ templates = {
       # github hosted runners are amd64
       # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
       # We prefer the github runners because they are smaller machines and save resources.
-      runs_on = "[[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
     }
   }
 }

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -26,7 +26,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
     }
   }
 }

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -16,7 +16,7 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
-      runs_on = "[[ubuntu-latest], [Ubuntu_ARM64_4C_16G_01]]",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['make functional']",
     }
   }
@@ -29,7 +29,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
     }
   }
 }

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -16,7 +16,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-latest]]",
+      runs_on = "[[ubuntu-22.04]]",
     }
   }
 }

--- a/terraform-plans/templates/github/charm_promote.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_promote.yaml.tftpl
@@ -19,7 +19,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set channels

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
           yamllint .yamllint snap/snapcraft.yaml
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/terraform-plans/templates/github/snap_promote.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_promote.yaml.tftpl
@@ -19,7 +19,7 @@ on:
 jobs:
   promote-snap:
     name: Promote snap
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Snapcraft install

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -17,7 +17,7 @@ jobs:
     secrets: inherit
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: check
     outputs:
       snap: $${{ steps.build.outputs.snap }}


### PR DESCRIPTION
With the release of 24.04.1, it's only a matter of time before GitHub
switches the ubuntu-latest image to use Noble. This change pins all
workflows to 22.04 (which is the current behavior) so that we can switch
from Jammy to Noble at our own pace.
