### PR TITLE
Ensure automated PRs are created, not duplicated

### DIFF
--- a/terraform-plans/modules/GitHub/templates/main.tf
+++ b/terraform-plans/modules/GitHub/templates/main.tf
@@ -12,13 +12,6 @@ provider "github" {
   app_auth {} # using environment variables for authentication
 }
 
-# Generate a unique string to append to the branch name
-resource "random_string" "update_uid" {
-  length  = 8
-  numeric = true
-  special = false
-}
-
 # Flatten the repository and file information into a single list of maps based on the templates variable
 locals {
   repo_files = flatten([

--- a/terraform-plans/modules/GitHub/templates/variables.tf
+++ b/terraform-plans/modules/GitHub/templates/variables.tf
@@ -17,7 +17,7 @@ variable "branch" {
 variable "pr_branch" {
   type        = string
   description = "Pull request branch name."
-  default     = "chore/update-managed-files"
+  default     = "automation/update-managed-files"
 }
 
 variable "pr_title" {


### PR DESCRIPTION
Previously there was the issue where a new PR to target repositories was created each time the terraform apply workflow runs, if there were outstanding changes to files.
This caused a lot of noise.

By using a consistent branch name and some extra logic,
we can ensure existing PRs are updated,
rather than creating new ones.

Fixes: #63