### PR TITLE
Remove dependency on project makefiles

### DIFF
--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -12,7 +12,7 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars        = {
       runs_on = "[[ubuntu-22.04]]",
-      test_commands = "['make functional']",
+      test_commands = "['tox -e func']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -12,7 +12,7 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars        = {
       runs_on = "[[ubuntu-22.04]]",
-      test_commands = "['FUNC_ARGS=\"--series focal\" make functional', 'FUNC_ARGS=\"--series jammy\" make functional']",
+      test_commands = "['tox -e func -- -v --series focal', 'tox -e func -- -v --series jammy']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -7,4 +7,24 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars        = {
+      runs_on = "[[self-hosted, linux, x64, large, jammy]]",
+      test_commands = "['tox -e func']",
+    }
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars        = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
 }

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -12,7 +12,7 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars        = {
       runs_on = "[[ubuntu-22.04]]",
-      test_commands = "['make functional']",
+      test_commands = "['tox -e func']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -17,7 +17,7 @@ templates = {
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['make functional']",
+      test_commands = "['tox -e func']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -7,4 +7,24 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars        = {
+      runs_on = "[[ubuntu-22.04]]",
+      test_commands = "['tox -e func']",
+    }
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars        = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
 }

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -12,7 +12,7 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars        = {
       runs_on = "[[ubuntu-22.04]]",
-      test_commands = "['make functional']",
+      test_commands = "['tox -e func']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -17,7 +17,7 @@ templates = {
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['make functional']",
+      test_commands = "['tox -e func']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -17,7 +17,7 @@ templates = {
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['make functional']",
+      test_commands = "['tox -e func']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -14,7 +14,7 @@ templates = {
       # Skip ARM64 check because the functional test runs on lxd VM which is not working
       # on arm64 right now.
       runs_on = "[[self-hosted, jammy, X64, large]]",
-      test_commands = "['make functional']",
+      test_commands = "['tox -e func']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -17,7 +17,7 @@ templates = {
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['make functional']",
+      test_commands = "['tox -e func']",
     }
   }
   promote = {

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -12,7 +12,7 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars        = {
       runs_on = "[[ubuntu-22.04]]",
-      test_commands = "['FUNC_ARGS=\"--series focal\" make functional', 'FUNC_ARGS=\"--series jammy\" make functional']",
+      test_commands = "['tox -e func -- -v --series focal', 'tox -e func -- -v --series jammy']",
     }
   }
   promote = {

--- a/terraform-plans/configs/openstack-exporter-operator_main.tfvars
+++ b/terraform-plans/configs/openstack-exporter-operator_main.tfvars
@@ -7,4 +7,17 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  # check.yaml is not added for now because it has a different format - to use an external juju controller.
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars        = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
 }

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -120,11 +120,13 @@ jobs:
         run: chharmcraft -v pack
 
       - name: Run tests
-        run: $${{ matrix.test-command }}
+        run: |
+          export CHARM_PATH="$(pwd)/$(ls | grep '\.charm$')"
+          echo "$CHARM_PATH"
+          $${{ matrix.test-command }}
         env:
           TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
           TEST_JUJU_CHANNEL: $${{ matrix.juju-channel }}
-          CHARM_PATH: "$${{ github.workspace}}/$${{ matrix.charm-file }}"
 
       # Save output for debugging
 

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -121,6 +121,10 @@ jobs:
 
       - name: Run tests
         run: |
+          # These variables are for a consistent method to find the charm file(s) across all projects.
+          # Not all charms will use them, and for some charms the variables will resolve to the same file.
+          export CHARM_PATH_NOBLE="$(pwd)/$(ls | grep '.*24.04.*\.charm$')"
+          echo "$CHARM_PATH_NOBLE"
           export CHARM_PATH_JAMMY="$(pwd)/$(ls | grep '.*22.04.*\.charm$')"
           echo "$CHARM_PATH_JAMMY"
           export CHARM_PATH_FOCAL="$(pwd)/$(ls | grep '.*20.04.*\.charm$')"

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -122,6 +122,8 @@ jobs:
       - name: Run tests
         run: |
           # These variables are for a consistent method to find the charm file(s) across all projects.
+          # It is designed to work both with charms that output one file per base,
+          # and charms that output a single file to run on all bases.
           # Not all charms will use them, and for some charms the variables will resolve to the same file.
           export CHARM_PATH_NOBLE="$(pwd)/$(ls | grep '.*24.04.*\.charm$')"
           echo "$CHARM_PATH_NOBLE"

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -116,11 +116,15 @@ jobs:
             echo "TEST_MODEL_CONSTRAINTS=arch=arm64" >> "$GITHUB_ENV"
           fi
 
+      - name: Build the charm
+        run: chharmcraft -v pack
+
       - name: Run tests
         run: $${{ matrix.test-command }}
         env:
           TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
           TEST_JUJU_CHANNEL: $${{ matrix.juju-channel }}
+          CHARM_PATH: "$${{ github.workspace}}/$${{ matrix.charm-file }}"
 
       # Save output for debugging
 

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -121,8 +121,10 @@ jobs:
 
       - name: Run tests
         run: |
-          export CHARM_PATH="$(pwd)/$(ls | grep '\.charm$')"
-          echo "$CHARM_PATH"
+          export CHARM_PATH_JAMMY="$(pwd)/$(ls | grep '.*22.04.*\.charm$')"
+          echo "$CHARM_PATH_JAMMY"
+          export CHARM_PATH_FOCAL="$(pwd)/$(ls | grep '.*20.04.*\.charm$')"
+          echo "$CHARM_PATH_FOCAL"
           $${{ matrix.test-command }}
         env:
           TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -117,7 +117,7 @@ jobs:
           fi
 
       - name: Build the charm
-        run: chharmcraft -v pack
+        run: charmcraft -v pack
 
       - name: Run tests
         run: |

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -91,11 +91,11 @@ jobs:
         with:
           submodules: true
 
-        # arm64 runners don't have make or gcc installed by default
+        # arm64 runners don't have gcc installed by default
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y make gcc
+          sudo apt install -y gcc
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Draft because we need to implement support in the projects' functional test suites before we can merge this.

Depends on:

- https://github.com/canonical/charm-advanced-routing/pull/54
- https://github.com/canonical/charm-apt-mirror/pull/50
- https://github.com/canonical/charm-juju-backup-all/pull/43
- https://github.com/canonical/charm-juju-local/pull/23
- https://github.com/canonical/charm-local-users/pull/46
- https://github.com/canonical/charm-logrotated/pull/45
- https://github.com/canonical/charm-nginx/pull/35
- https://github.com/canonical/charm-nrpe/pull/203
- https://github.com/canonical/charm-prometheus-libvirt-exporter/pull/50
- https://github.com/canonical/charm-sysconfig/pull/71
- https://github.com/canonical/charm-userdir-ldap/pull/47
- https://github.com/canonical/hardware-observer-operator/pull/316
- https://github.com/canonical/openstack-exporter-operator/pull/102