### PR TITLE
Pin ubuntu to jammy for lint and unit workflows

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.10"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.10"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
We have it pinned elsewhere, so this makes it consistent.