### PR TITLE
Pin tox and set python version for running the CI on snaps

### DIFF
--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -41,6 +41,9 @@ jobs:
           # workflows breaking all at once when a new major version is released.
           python -m pip install 'tox<5'
 
+      - name: Run linters
+        run: tox -e lint
+
       - name: Lint yaml files
         run: |
           yamllint .yamllint snap/snapcraft.yaml

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -27,10 +27,19 @@ jobs:
         with:
           fetch-depth: 0  # Complete git history is required to generate the version from git tags.
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install -y yamllint
+          python -m pip install --upgrade pip
+          # pin tox to the current major version to avoid
+          # workflows breaking all at once when a new major version is released.
+          python -m pip install 'tox<5'
 
       - name: Lint yaml files
         run: |


### PR DESCRIPTION
- snaps were missing the pinning on tox that can cause workflow breaks on major versions as it happens with charms
- setting python3.10 as the standard for running lint