### PR TITLE
ci: Add arm64 support for hardware-observer

### DIFF
--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -16,8 +16,8 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars        = {
-      runs_on = "[[ubuntu-22.04]]",
-      test_commands = "['tox -e func -- -v --series focal', 'tox -e func -- -v --series jammy']",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
+      test_commands = "['tox -e func -- -v --series focal --keep-model', 'tox -e func -- -v --series jammy --keep-model']",
     }
   }
   promote = {
@@ -29,7 +29,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars        = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
     }
   }
 }


### PR DESCRIPTION
Change config to what we have on https://github.com/canonical/charm-prometheus-libvirt-exporter/pull/37/files#diff-8af267359854d30b091fde763088e458bf27c8fedc056895f3104ef05b61f4b5 and add arm64 on release