### PR TITLE
Fix typo in hardware-observer-operator config

### DIFF
--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -17,7 +17,7 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars        = {
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['tox -e func -- -v --series focal --keep-model', 'tox -e func -- -v --series jammy --keep-model']",
+      test_commands = "['tox -e func -- -v --series focal --keep-models', 'tox -e func -- -v --series jammy --keep-models']",
     }
   }
   promote = {


### PR DESCRIPTION
hardware-observer-operator uses pytest-operator, not zaza, so it's `--keep-models`, not `--keep-model`.
ref. https://github.com/charmed-kubernetes/pytest-operator/blob/main/docs/reference.md