### PR TITLE
Fix snap builds in solutions-engineering CI

### DIFF
--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -63,7 +63,7 @@ jobs:
 
       - name: Verify snap builds successfully
         id: build
-        uses: snapcore/action-build@v1
+        uses: canonical/action-build@v1
 
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Complete git history is required to generate the version from git tags.
-      - uses: snapcore/action-build@v1
+      - uses: canonical/action-build@v1
         id: build
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV


### PR DESCRIPTION
Changes from snapcore/action-build@v1 to canonical/action-build@v1

As described on https://github.com/canonical/action-build/issues/82 the `snapcore` (forked project) is broken and switching to the canonical repo is fixing the issue