### PR TITLE
Remove the build on release once this is done on check

### DIFF
--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -23,23 +23,25 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ${runs_on}
-    outputs:
-      snap: $${{ steps.build.outputs.snap }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Complete git history is required to generate the version from git tags.
-      - uses: canonical/action-build@v1
-        id: build
+
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v4
+
+      - name: Download the built snap from check workflow
+        uses: actions/download-artifact@v4
         with:
-          name: snap_$${{ env.SYSTEM_ARCH }}
-          path: $${{ steps.build.outputs.snap }}
+          name: snap_${{ env.SYSTEM_ARCH }}
+
+      - name: Find the downloaded snap file
+        run: echo "SNAP_FILE=$(find . -name "*.snap")" >> $GITHUB_ENV
+
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: $${{ secrets.STORE_LOGIN }}
         with:
-          snap: $${{ steps.build.outputs.snap }}
+          snap: $${{ env.SNAP_FILE }}
           release: latest/edge

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -34,7 +34,7 @@ jobs:
       - name: Download the built snap from check workflow
         uses: actions/download-artifact@v4
         with:
-          name: snap_${{ env.SYSTEM_ARCH }}
+          name: snap_$${{ env.SYSTEM_ARCH }}
 
       - name: Find the downloaded snap file
         run: echo "SNAP_FILE=$(find . -name "*.snap")" >> $GITHUB_ENV


### PR DESCRIPTION
- building two times in the same run result into conflicts in Github action.