### PR TITLE
Manage jira_sync_config.yaml

### DIFF
--- a/terraform-plans/configs/bootstack-actions_main.tfvars
+++ b/terraform-plans/configs/bootstack-actions_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "software-engineering",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -32,4 +32,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "advanced-routing",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -32,4 +32,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "apt-mirror",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "cloudsupport",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "duplicity",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -32,4 +32,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "juju-backup-all",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -32,4 +32,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "juju-local",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -40,4 +40,12 @@ templates = {
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "local-users",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -32,4 +32,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "logrotated",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -32,4 +32,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "nginx",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -37,4 +37,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "nrpe",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -24,4 +24,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "openstack-service-checks",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "blackbox-exporter",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "juju-exporter",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -39,5 +39,13 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
     }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "libvirt-exporter",
+      epic_key   = "SOLENG-46"
+    }
+  }
   }
 }

--- a/terraform-plans/configs/charm-simple-streams_main.tfvars
+++ b/terraform-plans/configs/charm-simple-streams_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "simple-streams",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "storage-connector",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -34,4 +34,12 @@ templates = {
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "sysconfig",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -37,4 +37,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "userdir-ldap",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -17,4 +17,12 @@ templates = {
     destination = ".github/workflows/promote.yaml"
     vars   = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "openstack-exporter",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -36,4 +36,12 @@ templates = {
     destination = ".yamllint"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "dcgm",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -32,4 +32,12 @@ templates = {
       runs_on = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "hardware-observer",
+      epic_key   = "SOLENG-190"
+    }
+  }
 }

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "juju-backup-all",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/juju-lint_main.tfvars
+++ b/terraform-plans/configs/juju-lint_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "juju-lint",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/layer-beats-base_main.tfvars
+++ b/terraform-plans/configs/layer-beats-base_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "layer-beats-base",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/layer-filebeat_main.tfvars
+++ b/terraform-plans/configs/layer-filebeat_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "filebeat",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/openstack-exporter-operator_main.tfvars
+++ b/terraform-plans/configs/openstack-exporter-operator_main.tfvars
@@ -25,4 +25,12 @@ templates = {
       runs_on = "[[ubuntu-22.04]]",
     }
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "openstack-exporter",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "hardware-observer",
+      epic_key   = "SOLENG-190"
+    }
+  }
 }

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "juju-backup-all",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "juju-exporter",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "openstack-exporter",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -36,4 +36,12 @@ templates = {
     destination = ".yamllint"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "smartctl-exporter",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/snap-tempest-automation_main.tfvars
+++ b/terraform-plans/configs/snap-tempest-automation_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "cloud-validation",
+      epic_key   = "SOLENG-80"
+    }
+  }
 }

--- a/terraform-plans/configs/snap-tempest_main.tfvars
+++ b/terraform-plans/configs/snap-tempest_main.tfvars
@@ -12,4 +12,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "cloud-validation",
+      epic_key   = "SOLENG-80"
+    }
+  }
 }

--- a/terraform-plans/configs/solutions-engineering-automation_main.tfvars
+++ b/terraform-plans/configs/solutions-engineering-automation_main.tfvars
@@ -7,4 +7,12 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "software-engineering",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -36,4 +36,12 @@ templates = {
     destination = ".yamllint"
     vars        = {}
   }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component  = "tailscale",
+      epic_key   = "SOLENG-46"
+    }
+  }
 }

--- a/terraform-plans/templates/github/jira_sync_config.yaml.tftpl
+++ b/terraform-plans/templates/github/jira_sync_config.yaml.tftpl
@@ -23,7 +23,7 @@ settings:
     - ${component}
 
   # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
-  add_gh_comment: false
+  add_gh_comment: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
   epic_key: ${epic_key}


### PR DESCRIPTION
Manage `jira_sync_config.yaml` for the rest of the projects (exception: only apply to snap_tempest main branch)