### PR TITLE
Add more projects to the automation

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -1,4 +1,4 @@
-name: Apply new changes to SolEng repositories
+name: Run terraform
 
 on:
   workflow_dispatch:

--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -18,6 +18,7 @@ templates = {
     vars = {
       runs_on       = "[[ubuntu-22.04]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -18,6 +18,7 @@ templates = {
     vars = {
       runs_on       = "[[ubuntu-22.04]]",
       test_commands = "['tox -e func -- -v --series focal', 'tox -e func -- -v --series jammy']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -12,6 +12,27 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on       = "[[ubuntu-22.04]]",
+      test_commands = "['TEST_JUJU3=1 make functional']",
+      juju_channels = "[\"3.4/stable\"]",
+    }
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
   jira_sync_config = {
     source      = "./templates/github/jira_sync_config.yaml.tftpl"
     destination = ".github/.jira_sync_config.yaml"

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -24,7 +24,9 @@ templates = {
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    vars        = {}
+    vars        = {
+      charmcraft_channel = "2.x/stable",
+    }
   }
   release = {
     source      = "./templates/github/charm_release.yaml.tftpl"

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -33,6 +33,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      charmcraft_channel = "2.x/stable",
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -17,7 +17,7 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars = {
       runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['TEST_JUJU3=1 make functional']",
+      test_commands = "['tox -e func']",
       juju_channels = "[\"3.4/stable\"]",
     }
   }

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -24,7 +24,7 @@ templates = {
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    vars        = {
+    vars = {
       charmcraft_channel = "2.x/stable",
     }
   }
@@ -32,7 +32,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on            = "[[ubuntu-22.04]]",
       charmcraft_channel = "2.x/stable",
     }
   }

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -18,6 +18,7 @@ templates = {
     vars = {
       runs_on       = "[[self-hosted, linux, x64, large, jammy]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -18,6 +18,7 @@ templates = {
     vars = {
       runs_on       = "[[ubuntu-22.04]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -23,6 +23,7 @@ templates = {
       # - runs-on: [self-hosted, jammy, ARM64]
       runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -18,6 +18,7 @@ templates = {
     vars = {
       runs_on       = "[[ubuntu-22.04]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -18,6 +18,7 @@ templates = {
     vars = {
       runs_on       = "[[ubuntu-22.04]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -23,6 +23,7 @@ templates = {
       # - runs-on: [self-hosted, jammy, ARM64]
       runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -12,6 +12,27 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on       = "[[ubuntu-22.04]]",
+      test_commands = "['TEST_JUJU3=1 make functional']",
+      juju_channels = "[\"3.4/stable\"]",
+    }
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
   jira_sync_config = {
     source      = "./templates/github/jira_sync_config.yaml.tftpl"
     destination = ".github/.jira_sync_config.yaml"

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -24,7 +24,9 @@ templates = {
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    vars        = {}
+    vars        = {
+      charmcraft_channel = "2.x/stable",
+    }
   }
   release = {
     source      = "./templates/github/charm_release.yaml.tftpl"

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -33,6 +33,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      charmcraft_channel = "2.x/stable",
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -17,7 +17,7 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars = {
       runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['TEST_JUJU3=1 make functional']",
+      test_commands = "['tox -e func']",
       juju_channels = "[\"3.4/stable\"]",
     }
   }

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -24,7 +24,7 @@ templates = {
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    vars        = {
+    vars = {
       charmcraft_channel = "2.x/stable",
     }
   }
@@ -32,7 +32,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on            = "[[ubuntu-22.04]]",
       charmcraft_channel = "2.x/stable",
     }
   }

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -24,7 +24,9 @@ templates = {
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    vars        = {}
+    vars        = {
+      charmcraft_channel = "2.x/stable",
+    }
   }
   release = {
     source      = "./templates/github/charm_release.yaml.tftpl"

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -33,6 +33,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      charmcraft_channel = "2.x/stable",
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -24,7 +24,7 @@ templates = {
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    vars        = {
+    vars = {
       charmcraft_channel = "2.x/stable",
     }
   }
@@ -32,7 +32,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on            = "[[ubuntu-22.04]]",
       charmcraft_channel = "2.x/stable",
     }
   }

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -12,6 +12,27 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on       = "[[ubuntu-22.04]]",
+      test_commands = "['TEST_JUJU3=1 make functional']",
+      juju_channels = "[\"3.4/stable\", \"3.5/stable\"]",
+    }
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
   jira_sync_config = {
     source      = "./templates/github/jira_sync_config.yaml.tftpl"
     destination = ".github/.jira_sync_config.yaml"

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -23,6 +23,7 @@ templates = {
       # - runs-on: [self-hosted, jammy, ARM64]
       runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -12,6 +12,27 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on       = "[[ubuntu-22.04]]",
+      test_commands = "['TEST_JUJU3=1 make functional']",
+      juju_channels = "[\"3.4/stable\"]",
+    }
+  }
+  promote = {
+    source      = "./templates/github/charm_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/charm_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
   jira_sync_config = {
     source      = "./templates/github/jira_sync_config.yaml.tftpl"
     destination = ".github/.jira_sync_config.yaml"

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -24,7 +24,9 @@ templates = {
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    vars        = {}
+    vars        = {
+      charmcraft_channel = "2.x/stable",
+    }
   }
   release = {
     source      = "./templates/github/charm_release.yaml.tftpl"

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -33,6 +33,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      charmcraft_channel = "2.x/stable",
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -24,7 +24,7 @@ templates = {
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"
-    vars        = {
+    vars = {
       charmcraft_channel = "2.x/stable",
     }
   }
@@ -32,7 +32,7 @@ templates = {
     source      = "./templates/github/charm_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on            = "[[ubuntu-22.04]]",
       charmcraft_channel = "2.x/stable",
     }
   }

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -20,6 +20,7 @@ templates = {
       # on arm64 right now.
       runs_on       = "[[self-hosted, jammy, X64, large]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -23,6 +23,7 @@ templates = {
       # - runs-on: [self-hosted, jammy, ARM64]
       runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['tox -e func']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -18,6 +18,7 @@ templates = {
     vars = {
       runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
       test_commands = "['tox -e func -- -v --series focal --keep-models', 'tox -e func -- -v --series jammy --keep-models']",
+      juju_channels = "[\"3.4/stable\"]",
     }
   }
   promote = {

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -12,6 +12,25 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/snap_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
+  promote = {
+    source      = "./templates/github/snap_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/snap_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
   jira_sync_config = {
     source      = "./templates/github/jira_sync_config.yaml.tftpl"
     destination = ".github/.jira_sync_config.yaml"

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -12,6 +12,25 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/snap_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
+  promote = {
+    source      = "./templates/github/snap_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/snap_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
   jira_sync_config = {
     source      = "./templates/github/jira_sync_config.yaml.tftpl"
     destination = ".github/.jira_sync_config.yaml"

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -83,8 +83,8 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: ${runs_on}
-        test-command: ${test_commands}
-        juju-channel: ["3.4/stable"]
+        test-command: ${ test_commands }
+        juju-channel: ${ juju_channels }
     steps:
 
       - uses: actions/checkout@v4

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -90,7 +90,7 @@ jobs:
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
 
-      - name: Download the built snap
+      - name: Download snap file artifact
         uses: actions/download-artifact@v4
         with:
           name: snap_$${{ env.SYSTEM_ARCH }}
@@ -105,5 +105,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install 'tox<5'
 
-      - name: Run functional tests
-        run: tox -e func
+      - name: Run func tests
+        run: |
+          export TEST_SNAP="$(pwd)/$(ls | grep '.*_.*\.snap$')"
+          echo "$TEST_SNAP"
+          tox -e func


### PR DESCRIPTION
I need to add juju_channels to the configuration and use it in
charm_check template. Add TEST_CHARM env variable to snap_check
template.

Added the check, promote and release for:
 - charm-duplicty
 - charm-promethues-blackbox-exporter
 - charm-prometheus-juju-exporter
 - charm-storage-connector
 - prometheus-backupall-juju-exporter
 - prometheus-juju-exporter
    
related: #111
