### PR TITLE
Add headscale-snap and derper-snap repos

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -87,6 +87,8 @@ jobs:
             - snap-tempest_stable_zed
             - solutions-engineering-automation_main
             - tailscale-snap_main
+            - headscale-snap_main
+            - derper-snap_main
             - dcgm-snap_main
     steps:
       - name: Checkout branch

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -1,0 +1,47 @@
+repository             = "derper-snap"
+repository_description = "A snap package for Tailscale's DERP server https://tailscale.com/kb/1118/custom-derp-servers"
+branch                 = "main"
+templates = {
+  gitignore = {
+    source      = "./templates/github/gitignore.tftpl"
+    destination = ".gitignore"
+    vars        = {}
+  }
+  codeowners = {
+    source      = "./templates/github/CODEOWNERS.tftpl"
+    destination = ".github/CODEOWNERS"
+    vars        = {}
+  }
+  check = {
+    source      = "./templates/github/snap_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
+  promote = {
+    source      = "./templates/github/snap_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/snap_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
+  yamllint = {
+    source      = "./templates/github/snap_yamllint.yaml.tftpl"
+    destination = ".yamllint"
+    vars        = {}
+  }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component = "tailscale",
+      epic_key  = "SOLENG-46"
+    }
+  }
+}

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -1,0 +1,47 @@
+repository             = "headscale-snap"
+repository_description = "A snap package for https://github.com/juanfont/headscale"
+branch                 = "main"
+templates = {
+  gitignore = {
+    source      = "./templates/github/gitignore.tftpl"
+    destination = ".gitignore"
+    vars        = {}
+  }
+  codeowners = {
+    source      = "./templates/github/CODEOWNERS.tftpl"
+    destination = ".github/CODEOWNERS"
+    vars        = {}
+  }
+  check = {
+    source      = "./templates/github/snap_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
+  promote = {
+    source      = "./templates/github/snap_promote.yaml.tftpl"
+    destination = ".github/workflows/promote.yaml"
+    vars        = {}
+  }
+  release = {
+    source      = "./templates/github/snap_release.yaml.tftpl"
+    destination = ".github/workflows/release.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04]]",
+    }
+  }
+  yamllint = {
+    source      = "./templates/github/snap_yamllint.yaml.tftpl"
+    destination = ".yamllint"
+    vars        = {}
+  }
+  jira_sync_config = {
+    source      = "./templates/github/jira_sync_config.yaml.tftpl"
+    destination = ".github/.jira_sync_config.yaml"
+    vars = {
+      component = "tailscale",
+      epic_key  = "SOLENG-46"
+    }
+  }
+}


### PR DESCRIPTION
I copied the templates config from the tailscale-snap config - these should all be the same.

- https://github.com/canonical/headscale-snap
- https://github.com/canonical/derper-snap

We'll need to wait for our github application to be installed in the target repositories before we can merge this though - I've opened a request for this.