### PR TITLE
Auto-delete branches on PR merge

### DIFF
--- a/terraform-plans/modules/GitHub/settings/main.tf
+++ b/terraform-plans/modules/GitHub/settings/main.tf
@@ -27,7 +27,7 @@ resource "github_repository" "repo" {
   allow_auto_merge   = false
 
   allow_update_branch    = true
-  delete_branch_on_merge = false
+  delete_branch_on_merge = true
   vulnerability_alerts   = true
 
 }


### PR DESCRIPTION
As far as I know, we never have cases where we want to keep the branch after a PR has merged.
And if we do on a rare occasion,
it should be easy to restore the branch.

Auto-deleting brings some conveniences,
including more efficiency and less forgotten stale branches.

Fixes: #106