### PR TITLE
Add channels var to  snap_release workflow

### DIFF
--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -31,6 +31,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      channels = "latest/edge"
     }
   }
   yamllint = {

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -30,7 +30,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      runs_on  = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       channels = "latest/edge"
     }
   }

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -24,6 +24,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      channels = "latest/edge"
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -23,7 +23,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on  = "[[ubuntu-22.04]]",
       channels = "latest/edge"
     }
   }

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -38,6 +38,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      channels = "core24/edge,latest/edge"
     }
   }
   yamllint = {

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -37,7 +37,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      runs_on  = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       channels = "core24/edge,latest/edge"
     }
   }

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -30,7 +30,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on  = "[[ubuntu-22.04]]",
       channels = "latest/edge"
     }
   }

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -31,6 +31,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      channels = "latest/edge"
     }
   }
   yamllint = {

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -30,7 +30,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on  = "[[ubuntu-22.04]]",
       channels = "latest/edge"
     }
   }

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -31,6 +31,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      channels = "latest/edge"
     }
   }
   yamllint = {

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -30,7 +30,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on  = "[[ubuntu-22.04]]",
       channels = "latest/edge"
     }
   }

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -31,6 +31,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      channels = "latest/edge"
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -30,7 +30,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on  = "[[ubuntu-22.04]]",
       channels = "latest/edge"
     }
   }

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -31,6 +31,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      channels = "latest/edge"
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -38,6 +38,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      channels = "latest/edge"
     }
   }
   yamllint = {

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -37,7 +37,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      runs_on  = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       channels = "latest/edge"
     }
   }

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -30,7 +30,7 @@ templates = {
     source      = "./templates/github/snap_release.yaml.tftpl"
     destination = ".github/workflows/release.yaml"
     vars = {
-      runs_on = "[[ubuntu-22.04]]",
+      runs_on  = "[[ubuntu-22.04]]",
       channels = "latest/edge"
     }
   }

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -31,6 +31,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on = "[[ubuntu-22.04]]",
+      channels = "latest/edge"
     }
   }
   yamllint = {

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -44,4 +44,5 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: $${{ secrets.STORE_LOGIN }}
         with:
           snap: $${{ env.SNAP_FILE }}
-          release: latest/edge
+          # Comma-separated list of channels to release the snap to.
+          release: ${channels}


### PR DESCRIPTION
This PR is because we encountered an issue with the DCGM snap. Currently, the default track is `core24`, so we don't automatically push any revisions to that channel. Also, we might want to keep the `latest` in sync.

I looked at the source code of the action we use to release the snaps; this change should work. Check out the change for the dcgm snap - it has a comma-separated list of the channels. And according to the help from the `snapcraft upload`, you can do that:

Action source code: https://github.com/canonical/action-publish/blob/214b86e5ca036ead1668c79afb81e550e6c54d40/src/publish.ts#L54

```
...
Summary:
    By passing --release with a comma-separated list of channels the snap would
    be released to the selected channels if the store review passes for this
    <snap-file>.
...
```

**It should work in theory.**

In addition, I am wondering if I should add additional quotes. Like this: 

```
...
vars = {
      runs_on  = "[[ubuntu-22.04]]",
      channels = "'core24/edge,latest/edge'"
}
...
```

Please let me know if you have any suggestions on how to test the changes other than merging them. 