### PR TITLE
Update channels var for release for p-j-e

### DIFF
--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -31,7 +31,7 @@ templates = {
     destination = ".github/workflows/release.yaml"
     vars = {
       runs_on  = "[[ubuntu-22.04]]",
-      channels = "latest/edge"
+      channels = "latest/edge,3/edge"
     }
   }
   jira_sync_config = {


### PR DESCRIPTION
Since we have the new template variable,
we can reconcile the template with what is actually in the repository at https://github.com/canonical/prometheus-juju-exporter/blob/70afa06/.github/workflows/release.yaml#L47