### PR TITLE
Temporarily disable check.yaml for the following projects

### DIFF
--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -12,15 +12,16 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
-  check = {
-    source      = "./templates/github/charm_check.yaml.tftpl"
-    destination = ".github/workflows/check.yaml"
-    vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['TEST_JUJU3=1 make functional']",
-      juju_channels = "[\"3.4/stable\", \"3.5/stable\"]",
-    }
-  }
+  # Temporarily disable it since the charm uses a different template
+  # check = {
+  #   source      = "./templates/github/charm_check.yaml.tftpl"
+  #   destination = ".github/workflows/check.yaml"
+  #   vars = {
+  #     runs_on       = "[[ubuntu-22.04]]",
+  #     test_commands = "['TEST_JUJU3=1 make functional']",
+  #     juju_channels = "[\"3.4/stable\", \"3.5/stable\"]",
+  #   }
+  # }
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -12,15 +12,16 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
-  check = {
-    source      = "./templates/github/charm_check.yaml.tftpl"
-    destination = ".github/workflows/check.yaml"
-    vars = {
-      runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['tox -e func -- -v --series focal --keep-models', 'tox -e func -- -v --series jammy --keep-models']",
-      juju_channels = "[\"3.4/stable\"]",
-    }
-  }
+  # Temporarily disable it since the charm uses a different template
+  # check = {
+  #   source      = "./templates/github/charm_check.yaml.tftpl"
+  #   destination = ".github/workflows/check.yaml"
+  #   vars = {
+  #     runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
+  #     test_commands = "['tox -e func -- -v --series focal --keep-models', 'tox -e func -- -v --series jammy --keep-models']",
+  #     juju_channels = "[\"3.4/stable\"]",
+  #   }
+  # }
   promote = {
     source      = "./templates/github/charm_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -12,13 +12,14 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
-  check = {
-    source      = "./templates/github/snap_check.yaml.tftpl"
-    destination = ".github/workflows/check.yaml"
-    vars = {
-      runs_on = "[[ubuntu-22.04]]",
-    }
-  }
+  # Temporarily disable it since the snap uses a different template
+  # check = {
+  #   source      = "./templates/github/snap_check.yaml.tftpl"
+  #   destination = ".github/workflows/check.yaml"
+  #   vars = {
+  #     runs_on = "[[ubuntu-22.04]]",
+  #   }
+  # }
   promote = {
     source      = "./templates/github/snap_promote.yaml.tftpl"
     destination = ".github/workflows/promote.yaml"


### PR DESCRIPTION
Temporarily disable `check.yaml` for the following projects since they don't fit in existing template

- charm-prometheus-juju-exporter
- prometheus-juju-exporter
- hardware-observer-operator