### PR TITLE
Attempted corrections for a few issues found in PR #140

### DIFF
--- a/terraform-plans/templates/github/pyproject.toml.tftpl
+++ b/terraform-plans/templates/github/pyproject.toml.tftpl
@@ -20,7 +20,6 @@ exclude = [
     "venv",
     ".venv",
     "report",
-    "lib",
 ]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
@@ -28,7 +27,7 @@ select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore D415 Docstring first line punctuation (doesn't make sense for properties)
 # Ignore N818 Exceptions end with "Error" (not all exceptions are errors)
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-ignore = ["C901", "W503", "E501", "D107", "D415", "N818", "D100", "D101", "D102", "D103"]
+ignore = ["C901", "W503", "E501", "D107", "D415", "N818", "D100", "D101", "D102", "D103", "W504"]
 per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
 # Check for properly formatted copyright header in each file
 copyright-check = "True"


### PR DESCRIPTION
In #140, I noted a few errata, but as the code was breaking other projects by leaving it as-is, I allowed the short-term merge without changes.

There were 2 notable issues I noted in #140 which concerned me:

* We dropped an ignore clause for pyflake warning W504.
* We added some additional paths to exclude, which I generally was OK with, except for adding the "lib" path.  I'm concerned this may unexpectedly skip flake8 checking in some modules where we may want those checks.

Please let me know what you think.