### PR TITLE
Add var for coverage in pyproject.toml

### DIFF
--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "90"
+    }
   }
 }

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "90"
+    vars = {
+      coverage_threshold_percent = "90"
     }
   }
 }

--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "98"
+    }
   }
 }

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "98"
+    vars = {
+      coverage_threshold_percent = "98"
     }
   }
 }

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "95"
+    vars = {
+      coverage_threshold_percent = "95"
     }
   }
 }

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "95"
+    }
   }
 }

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -64,6 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -65,7 +65,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "75"
     }
   }
 }

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -64,8 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -57,7 +57,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "0"
     }
   }
 }

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -61,8 +61,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -61,6 +61,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -57,7 +57,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "50"
     }
   }
 }

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -56,6 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -56,8 +56,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -55,8 +55,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -55,6 +55,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -64,6 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -64,8 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-simple-streams_main.tfvars
+++ b/terraform-plans/configs/charm-simple-streams_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-simple-streams_main.tfvars
+++ b/terraform-plans/configs/charm-simple-streams_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -63,6 +63,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -63,8 +63,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -58,8 +58,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -58,6 +58,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -61,8 +61,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -61,6 +61,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -64,6 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -64,8 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -45,8 +45,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -45,6 +45,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -64,6 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -64,8 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -57,8 +57,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -57,6 +57,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -55,8 +55,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -42,7 +42,7 @@ templates = {
     destination = ".github/.jira_sync_config.yaml"
     vars = {
       component = "hardware-observer",
-      epic_key  = "SOLENG-190"
+      epic_key  = "SOLENG-1100"
     }
   }
   security = {
@@ -55,6 +55,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -42,7 +42,7 @@ templates = {
     destination = ".github/.jira_sync_config.yaml"
     vars = {
       component = "hardware-observer",
-      epic_key  = "SOLENG-1100"
+      epic_key  = "SOLENG-190"
     }
   }
   security = {

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -57,8 +57,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -57,6 +57,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/juju-lint_main.tfvars
+++ b/terraform-plans/configs/juju-lint_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/juju-lint_main.tfvars
+++ b/terraform-plans/configs/juju-lint_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/layer-beats-base_main.tfvars
+++ b/terraform-plans/configs/layer-beats-base_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/layer-beats-base_main.tfvars
+++ b/terraform-plans/configs/layer-beats-base_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/layer-filebeat_main.tfvars
+++ b/terraform-plans/configs/layer-filebeat_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/layer-filebeat_main.tfvars
+++ b/terraform-plans/configs/layer-filebeat_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
@@ -17,7 +17,7 @@ templates = {
     destination = ".github/.jira_sync_config.yaml"
     vars = {
       component = "hardware-observer",
-      epic_key  = "SOLENG-190"
+      epic_key  = "SOLENG-1100"
     }
   }
   security = {
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -52,8 +52,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -52,6 +52,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -53,8 +53,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -53,6 +53,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -65,7 +65,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "0"
     }
   }
 }

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -51,7 +51,7 @@ templates = {
     destination = ".github/.jira_sync_config.yaml"
     vars = {
       component = "smartctl-exporter",
-      epic_key  = "SOLENG-190"
+      epic_key  = "SOLENG-1100"
     }
   }
   security = {
@@ -64,6 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -64,8 +64,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest-automation_main.tfvars
+++ b/terraform-plans/configs/snap-tempest-automation_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest-automation_main.tfvars
+++ b/terraform-plans/configs/snap-tempest-automation_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_main.tfvars
+++ b/terraform-plans/configs/snap-tempest_main.tfvars
@@ -30,8 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_main.tfvars
+++ b/terraform-plans/configs/snap-tempest_main.tfvars
@@ -30,6 +30,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_antelope.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_antelope.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_antelope.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_antelope.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_bobcat.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_bobcat.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_bobcat.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_bobcat.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_caracal.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_caracal.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_caracal.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_caracal.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_ussuri.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_ussuri.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_ussuri.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_ussuri.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_victoria.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_victoria.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_victoria.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_victoria.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_wallaby.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_wallaby.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_wallaby.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_wallaby.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_xena.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_xena.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_xena.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_xena.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_yoga.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_yoga.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_yoga.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_yoga.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_zed.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_zed.tfvars
@@ -15,6 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_zed.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_zed.tfvars
@@ -15,8 +15,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -57,8 +57,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {
-        coverage_threshold_percent = "100"
+    vars = {
+      coverage_threshold_percent = "100"
     }
   }
 }

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -57,6 +57,8 @@ templates = {
   pyproject = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
-    vars        = {}
+    vars        = {
+        coverage_threshold_percent = "100"
+    }
   }
 }

--- a/terraform-plans/templates/github/pyproject.toml.tftpl
+++ b/terraform-plans/templates/github/pyproject.toml.tftpl
@@ -27,7 +27,7 @@ select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore D415 Docstring first line punctuation (doesn't make sense for properties)
 # Ignore N818 Exceptions end with "Error" (not all exceptions are errors)
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-ignore = ["C901", "W503", "E501", "D107", "D415", "N818", "D100", "D101", "D102", "D103", "W504"]
+ignore = ["C1001", "W503", "E501", "D107", "D415", "N818", "D100", "D101", "D102", "D103", "W504"]
 per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
 # Check for properly formatted copyright header in each file
 copyright-check = "True"
@@ -86,7 +86,7 @@ source = ["."]
 omit = ["tests/**", "docs/**", "lib/**", "snap/**", "build/**", "setup.py"]
 
 [tool.coverage.report]
-fail_under = 100
+fail_under = ${coverage_threshold_percent}
 show_missing = true
 
 [tool.coverage.html]

--- a/terraform-plans/templates/github/pyproject.toml.tftpl
+++ b/terraform-plans/templates/github/pyproject.toml.tftpl
@@ -20,6 +20,7 @@ exclude = [
     "venv",
     ".venv",
     "report",
+    "docs",
 ]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this


### PR DESCRIPTION
Some projects don't have 100% coverage,
so we can make exceptions here.

Also ignore the docs dir in flake8 config (docs is ignored for other tools, so this makes it consistent).