### PR TITLE
Add charmcraft and python versions to charm check

### DIFF
--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['tox -e func -- -v --series focal', 'tox -e func -- -v --series jammy']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04]]",
+      test_commands      = "['tox -e func -- -v --series focal', 'tox -e func -- -v --series jammy']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[self-hosted, linux, x64, large, jammy]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[self-hosted, linux, x64, large, jammy]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -21,9 +21,11 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
-      runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -21,9 +21,11 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
-      runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -21,9 +21,11 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
-      runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -16,9 +16,10 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[[ubuntu-22.04]]",
-      test_commands = "['TEST_JUJU3=1 make functional']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04]]",
+      test_commands      = "['TEST_JUJU3=1 make functional']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -20,6 +20,7 @@ templates = {
       test_commands      = "['TEST_JUJU3=1 make functional']",
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -18,9 +18,11 @@ templates = {
     vars = {
       # Skip ARM64 check because the functional test runs on lxd VM which is not working
       # on arm64 right now.
-      runs_on       = "[[self-hosted, jammy, X64, large]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[self-hosted, jammy, X64, large]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -21,9 +21,11 @@ templates = {
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
-      runs_on       = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
-      test_commands = "['tox -e func']",
-      juju_channels = "[\"3.4/stable\"]",
+      runs_on            = "[[ubuntu-22.04], [Ubuntu_ARM64_4C_16G_01]]",
+      test_commands      = "['tox -e func']",
+      juju_channels      = "[\"3.4/stable\"]",
+      charmcraft_channel = "2.x/stable",
+      python_versions    = "['3.8', '3.10']",
     }
   }
   promote = {

--- a/terraform-plans/configs/openstack-exporter-operator_main.tfvars
+++ b/terraform-plans/configs/openstack-exporter-operator_main.tfvars
@@ -16,9 +16,11 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on       = "[['self-hosted', 'jammy', 'amd64', 'two-xlarge']]",
-      test_commands = "['TEST_MODEL_SETTINGS=\"update-status-hook-interval=30s\" tox -e func']",
-      juju_channels = "['3.4/stable']",
+      runs_on            = "[['self-hosted', 'jammy', 'amd64', 'two-xlarge']]",
+      test_commands      = "['TEST_MODEL_SETTINGS=\"update-status-hook-interval=30s\" tox -e func']",
+      juju_channels      = "['3.4/stable']",
+      charmcraft_channel = "3.x/stable",
+      python_versions    = "['3.10']",
     }
   }
   promote = {

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ${ python_versions }
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ${ python_versions }
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
         with:
           provider: "lxd"
           juju-channel: $${{ matrix.juju-channel }}
-          charmcraft-channel: "2.x/stable"
+          charmcraft-channel: "${ charmcraft_channel j"
 
         # This is used by zaza in the functional tests for non-amd64 architectures (if applicable)
       - name: Set zaza juju model constraints for architecture

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -107,7 +107,7 @@ jobs:
         with:
           provider: "lxd"
           juju-channel: $${{ matrix.juju-channel }}
-          charmcraft-channel: "${ charmcraft_channel j"
+          charmcraft-channel: "${ charmcraft_channel }"
 
         # This is used by zaza in the functional tests for non-amd64 architectures (if applicable)
       - name: Set zaza juju model constraints for architecture


### PR DESCRIPTION
Some projects now use charmcraft 3, while many still use charmcraft 2, so we need a variable for the charm check.yaml template now.

Similarly for python versions - it was hardcoded to 3.8 and 3.10, but some projects don't support python 3.8 (focal) any more, so we only run tests on python 3.10 (jammy).
So we need a variable there to manage python versions per-project.