### PR TITLE
Add check.yaml to prometheus-openstack-exporter

### DIFF
--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -12,6 +12,13 @@ templates = {
     destination = ".github/CODEOWNERS"
     vars        = {}
   }
+  check = {
+    source      = "./templates/github/snap_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+    }
+  }
   jira_sync_config = {
     source      = "./templates/github/jira_sync_config.yaml.tftpl"
     destination = ".github/.jira_sync_config.yaml"


### PR DESCRIPTION
This was already added to the prometheus-openstack-exporter repo in https://github.com/canonical/prometheus-openstack-exporter/pull/143 , but here we need to add it to automation.