### PR TITLE
Lower coverage bar for charm-advanced-routing (and fix typo)

### DIFF
--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -57,7 +57,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "20"
     }
   }
 }

--- a/terraform-plans/templates/github/pyproject.toml.tftpl
+++ b/terraform-plans/templates/github/pyproject.toml.tftpl
@@ -28,7 +28,7 @@ select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore D415 Docstring first line punctuation (doesn't make sense for properties)
 # Ignore N818 Exceptions end with "Error" (not all exceptions are errors)
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-ignore = ["C1001", "W503", "E501", "D107", "D415", "N818", "D100", "D101", "D102", "D103", "W504"]
+ignore = ["C901", "W503", "E501", "D107", "D415", "N818", "D100", "D101", "D102", "D103", "W504"]
 per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
 # Check for properly formatted copyright header in each file
 copyright-check = "True"


### PR DESCRIPTION
This is another project that doesn't meet 100% yet, so we can lower the bar for now to unblock merging the automated PRs.

Also fix a typo in the flake8 ignore rules. (follow up to #143 )