### PR TITLE
More updates for pyproject.toml, fix typos

### DIFF
--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -62,7 +62,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "60"
     }
   }
 }

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -62,7 +62,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "60"
     }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -65,7 +65,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "0"
     }
   }
 }

--- a/terraform-plans/configs/layer-beats-base_main.tfvars
+++ b/terraform-plans/configs/layer-beats-base_main.tfvars
@@ -31,7 +31,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "60"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
@@ -17,7 +17,7 @@ templates = {
     destination = ".github/.jira_sync_config.yaml"
     vars = {
       component = "hardware-observer",
-      epic_key  = "SOLENG-1100"
+      epic_key  = "SOLENG-190"
     }
   }
   security = {

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -51,7 +51,7 @@ templates = {
     destination = ".github/.jira_sync_config.yaml"
     vars = {
       component = "smartctl-exporter",
-      epic_key  = "SOLENG-1100"
+      epic_key  = "SOLENG-190"
     }
   }
   security = {

--- a/terraform-plans/templates/github/pyproject.toml.tftpl
+++ b/terraform-plans/templates/github/pyproject.toml.tftpl
@@ -22,6 +22,9 @@ exclude = [
     "report",
     "docs",
     "lib",
+    "mod",
+    "hooks/charmhelpers",
+    "tests/charmhelpers",
 ]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
@@ -49,18 +52,21 @@ exclude = '''
     | lib
     | report
     | docs
+    | mod
+    | hooks/charmhelpers
+    | tests/charmhelpers
 )/
 '''
 
 [tool.isort]
 profile = "black"
 line_length = 99
-skip_glob = [".eggs", ".git", ".tox", ".venv", ".build", "build", "lib", "report"]
+skip_glob = [".eggs", ".git", ".tox", ".venv", ".build", "build", "lib", "report", "mod", "hooks/charmhelpers", "tests/charmhelpers"]
 
 [tool.pylint]
 max-line-length = 99
 disable = ["E1102"]
-ignore = ['.eggs', '.git', '.tox', '.venv', '.build', 'lib', 'report', 'tests', 'docs']
+ignore = ['.eggs', '.git', '.tox', '.venv', '.build', 'lib', 'report', 'tests', 'docs', "mod", "hooks/charmhelpers", "tests/charmhelpers"]
 
 [tool.mypy]
 warn_unused_ignores = true
@@ -69,10 +75,10 @@ warn_unreachable = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
 no_namespace_packages = true
-exclude = ['.eggs', '.git', '.tox', '.venv', '.build', 'lib', 'report', 'tests', 'docs']
+exclude = ['.eggs', '.git', '.tox', '.venv', '.build', 'lib', 'report', 'tests', 'docs', "mod", "hooks/charmhelpers", "tests/charmhelpers"]
 
 [tool.codespell]
-skip = ".eggs,.tox,.git,.venv,venv,build,.build,lib,report,docs,poetry.lock,htmlcov"
+skip = ".eggs,.tox,.git,.venv,venv,build,.build,lib,report,docs,poetry.lock,htmlcov,mod,hooks/charmhelpers,tests/charmhelpers"
 quiet-level = 3
 check-filenames = true
 ignore-words-list = "assertIn"
@@ -85,7 +91,7 @@ ignore_missing_imports = true
 [tool.coverage.run]
 relative_files = true
 source = ["."]
-omit = ["tests/**", "docs/**", "lib/**", "snap/**", "build/**", "setup.py"]
+omit = ["tests/**", "docs/**", "lib/**", "snap/**", "build/**", "setup.py", "mod/**", "hooks/charmhelpers/**", "tests/charmhelpers/**"]
 
 [tool.coverage.report]
 fail_under = ${coverage_threshold_percent}

--- a/terraform-plans/templates/github/pyproject.toml.tftpl
+++ b/terraform-plans/templates/github/pyproject.toml.tftpl
@@ -21,6 +21,7 @@ exclude = [
     ".venv",
     "report",
     "docs",
+    "lib",
 ]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this


### PR DESCRIPTION
- Fix some typos from #143 - the epic key shouldn't have changed.
- Exclude the `lib` directory for flake8 (this dir is used mostly for upstream charmcraft libraries).
- Exclude the `mod` directory, and various charmhelpers directories - these are used for inlining the upstream charmhelpers source in some repos, so shouldn't be included in lints.
- Reduce the coverage requirements for more repos.