### PR TITLE
Add automation for check in charm-cloudsupport

### DIFF
--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -34,4 +34,15 @@ templates = {
       coverage_threshold_percent = "100"
     }
   }
+  check = {
+    source      = "./templates/github/charm_check.yaml.tftpl"
+    destination = ".github/workflows/check.yaml"
+    vars = {
+      runs_on            = "[['self-hosted', 'jammy', 'amd64', 'two-xlarge']]",
+      test_commands      = "['TEST_MODEL_SETTINGS=\"update-status-hook-interval=30s\" tox -e func']",
+      juju_channels      = "['3.4/stable']",
+      charmcraft_channel = "3.x/stable",
+      python_versions    = "['3.10']",
+    }
+  }
 }


### PR DESCRIPTION
After https://github.com/canonical/charm-cloudsupport/pull/48 we can add the automation for the project to use self-hosted runners