### PR TITLE
Reduce coverage threshold for more projects

### DIFF
--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -31,7 +31,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "50"
     }
   }
 }

--- a/terraform-plans/configs/charm-simple-streams_main.tfvars
+++ b/terraform-plans/configs/charm-simple-streams_main.tfvars
@@ -31,7 +31,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "90"
     }
   }
 }

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -65,7 +65,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "0"
     }
   }
 }

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -31,7 +31,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "90"
     }
   }
 }


### PR DESCRIPTION
These are the remaining projects which don't have 100% coverage. For now we can reduce the coverage threshold to unblock the CI. We can increase the thresholds later if we work on adding more tests.