### PR TITLE
Add repo homepage url variable

### DIFF
--- a/terraform-plans/configs/openstack-exporter-operator_main.tfvars
+++ b/terraform-plans/configs/openstack-exporter-operator_main.tfvars
@@ -1,6 +1,7 @@
-repository             = "openstack-exporter-operator"
-repository_description = "The openstack-exporter-operator is a machine charm for openstack-exporter."
-branch                 = "main"
+repository              = "openstack-exporter-operator"
+repository_description  = "The openstack-exporter-operator is a machine charm for openstack-exporter."
+repository_homepage_url = "https://charmhub.io/openstack-exporter"
+branch                  = "main"
 templates = {
   gitignore = {
     source      = "./templates/github/gitignore.tftpl"

--- a/terraform-plans/modules/GitHub/settings/main.tf
+++ b/terraform-plans/modules/GitHub/settings/main.tf
@@ -13,8 +13,9 @@ provider "github" {
 }
 
 resource "github_repository" "repo" {
-  name        = var.repository
-  description = var.repository_description
+  name         = var.repository
+  description  = var.repository_description
+  homepage_url = var.repository_homepage_url
 
   has_issues      = true
   has_projects    = false

--- a/terraform-plans/modules/GitHub/settings/variables.tf
+++ b/terraform-plans/modules/GitHub/settings/variables.tf
@@ -13,6 +13,12 @@ variable "repository_description" {
   description = "GitHub repository description"
 }
 
+variable "repository_homepage_url" {
+  type        = string
+  description = "GitHub repository homepage url (used for linking to charmhub pages, etc.)"
+  default     = ""
+}
+
 variable "branch" {
   type        = string
   description = "Branch name"


### PR DESCRIPTION
And set the url for openstack-exporter-operator.
This also lets us set the url for other projects in the future too.

Note: with or without this patch,
the homepage url (website) in repository description must be set from automation,
otherwise the terraform here will overwrite it to an empty string.

Fixes: https://github.com/canonical/openstack-exporter-operator/issues/121