### PR TITLE
Standardize Allowed GitHub Actions on SolEng projects

### DIFF
--- a/terraform-plans/modules/GitHub/settings/main.tf
+++ b/terraform-plans/modules/GitHub/settings/main.tf
@@ -32,6 +32,25 @@ resource "github_repository" "repo" {
 
 }
 
+resource "github_actions_repository_permissions" "repo" {
+  repository      =  var.repository
+  allowed_actions = "selected"
+
+  allowed_actions_config {
+    github_owned_allowed = true
+
+    verified_allowed = false
+
+    patterns_allowed = [
+      beliaev-maksim/github-to-jira-automation/.github/workflows/issues_to_jira.yaml@master,
+      canonical/*,
+      snapcore/*,
+      charmed-kubernetes/*,
+      tiobe/*,
+    ]
+  }
+}
+
 data "github_team" "admins" {
   slug = "soleng-admin"
 }

--- a/terraform-plans/modules/GitHub/settings/main.tf
+++ b/terraform-plans/modules/GitHub/settings/main.tf
@@ -34,7 +34,7 @@ resource "github_repository" "repo" {
 }
 
 resource "github_actions_repository_permissions" "repo" {
-  repository      =  var.repository
+  repository      = var.repository
   allowed_actions = "selected"
 
   allowed_actions_config {
@@ -43,11 +43,11 @@ resource "github_actions_repository_permissions" "repo" {
     verified_allowed = false
 
     patterns_allowed = [
-      beliaev-maksim/github-to-jira-automation/.github/workflows/issues_to_jira.yaml@master,
-      canonical/*,
-      snapcore/*,
-      charmed-kubernetes/*,
-      tiobe/*,
+      "beliaev-maksim/github-to-jira-automation/.github/workflows/issues_to_jira.yaml@master",
+      "canonical/*",
+      "snapcore/*",
+      "charmed-kubernetes/*",
+      "tiobe/*",
     ]
   }
 }


### PR DESCRIPTION
Some projects have full permissions to allow all actions and reusable workflows that can be a security issue.

With this PR, all projects will run actions or reusable workflows that are created by GitHub or with the following pattern:
- canonical/*
- snapcore/*
- charmed-kubernetes/*
- tiobe/*
- beliaev-maksim/github-to-jira-automation/.github/workflows/issues_to_jira.yaml@master

See more information about how to configure those options in the terraform [documentation](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_repository_permissions)

With those changes the idea is to have repos configured like this:

![image](https://github.com/user-attachments/assets/305dbf8c-5473-4755-aa1f-aece053830c8)
