### PR TITLE
Add tics integration for charm projects

### DIFF
--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-advanced-routing"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-advanced-routing"
+      tics_project       = "charm-advanced-routing"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-apt-mirror"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-apt-mirror"
+      tics_project       = "charm-apt-mirror"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -43,6 +43,7 @@ templates = {
       juju_channels      = "['3.4/stable']",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.10']",
+      project            = "charm-cloudsupport"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -43,7 +43,7 @@ templates = {
       juju_channels      = "['3.4/stable']",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.10']",
-      project            = "charm-cloudsupport"
+      tics_project       = "charm-cloudsupport"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "2.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-duplicity"
+      tics_project       = "charm-duplicity"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "2.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-duplicity"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10', '3.12']",
+      project            = "charm-juju-backup-all"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10', '3.12']",
-      project            = "charm-juju-backup-all"
+      tics_project       = "charm-juju-backup-all"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "2.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-juju-local"
+      tics_project       = "charm-juju-local"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "2.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-juju-local"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -26,7 +26,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10', '3.12']",
-      project            = "charm-local-users"
+      tics_project       = "charm-local-users"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -26,6 +26,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10', '3.12']",
+      project            = "charm-local-users"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-logrotated"
+      tics_project       = "charm-logrotated"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-logrotated"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-nginx"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-nginx"
+      tics_project       = "charm-nginx"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -26,6 +26,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-nrpe"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -26,7 +26,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-nrpe"
+      tics_project       = "charm-nrpe"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "['3.4/stable']",
       charmcraft_channel = "2.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-openstack-service-checks"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "['3.4/stable']",
       charmcraft_channel = "2.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-openstack-service-checks"
+      tics_project       = "charm-openstack-service-checks"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "2.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-prometheus-blackbox-exporter"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "2.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-prometheus-blackbox-exporter"
+      tics_project       = "charm-prometheus-blackbox-exporter"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -26,7 +26,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-prometheus-libvirt-exporter"
+      tics_project       = "charm-prometheus-libvirt-exporter"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -26,6 +26,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-prometheus-libvirt-exporter"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-storage-connector"
+      tics_project       = "charm-storage-connector"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-storage-connector"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
+      project            = "charm-sysconfig"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
-      project            = "charm-sysconfig"
+      tics_project       = "charm-sysconfig"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -26,6 +26,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10', '3.12']",
+      project            = "charm-userdir-ldap"
     }
   }
   promote = {

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -26,7 +26,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10', '3.12']",
-      project            = "charm-userdir-ldap"
+      tics_project       = "charm-userdir-ldap"
     }
   }
   promote = {

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -21,7 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10', '3.12']",
-      project            = "hardware-observer-operator"
+      tics_project       = "hardware-observer-operator"
     }
   }
   promote = {

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -21,6 +21,7 @@ templates = {
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10', '3.12']",
+      project            = "hardware-observer-operator"
     }
   }
   promote = {

--- a/terraform-plans/configs/openstack-exporter-operator_main.tfvars
+++ b/terraform-plans/configs/openstack-exporter-operator_main.tfvars
@@ -22,6 +22,7 @@ templates = {
       juju_channels      = "['3.4/stable']",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.10']",
+      project            = "openstack-exporter-operator"
     }
   }
   promote = {

--- a/terraform-plans/configs/openstack-exporter-operator_main.tfvars
+++ b/terraform-plans/configs/openstack-exporter-operator_main.tfvars
@@ -22,7 +22,7 @@ templates = {
       juju_channels      = "['3.4/stable']",
       charmcraft_channel = "3.x/stable",
       python_versions    = "['3.10']",
-      project            = "openstack-exporter-operator"
+      tics_project       = "openstack-exporter-operator"
     }
   }
   promote = {

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -289,7 +289,7 @@ jobs:
         uses: tiobe/tics-github-action@v3
         with:
           mode: qserver
-          project: ${project}
+          project: ${tics_project}
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           branchdir: $${{ github.workspace }}
           ticsAuthToken: $${{ secrets.TICSAUTHTOKEN }}

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -243,7 +243,7 @@ jobs:
           path: "$${{ env.CRASHDUMPS_DIR }}/juju-crashdump-*.tar.xz"
 
   tics-analysis:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
     if: >
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -243,7 +243,7 @@ jobs:
           path: "$${{ env.CRASHDUMPS_DIR }}/juju-crashdump-*.tar.xz"
 
   tics-analysis:
-    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+    runs-on: ubuntu-22.04
     if: >
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -203,7 +203,7 @@ jobs:
           include-hidden-files: true
           if-no-files-found: ignore
           name: coverage-functional-$${{ env.SYSTEM_ARCH }}
-          path: .coverage-functional
+          path: .coverage-func
 
       # Save output for debugging
 

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -72,6 +72,17 @@ jobs:
     - name: Run unit tests
       run: tox -e unit
 
+    - name: Determine system architecture
+      run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
+
+    - name: Upload Unit Test Coverage File
+      uses: actions/upload-artifact@v4
+      with:
+        include-hidden-files: true
+        if-no-files-found: ignore
+        name: coverage-unit-$${{ matrix.python-version }}-$${{ env.SYSTEM_ARCH }}
+        path: .coverage-unit
+
   build:
     needs:
       - lint
@@ -181,6 +192,19 @@ jobs:
           TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
           TEST_JUJU_CHANNEL: $${{ matrix.juju-channel }}
 
+      - name: Generate Safe Test Command Identifier by removing spaces and special characters
+        run: |
+          TEST_CMD_ID=$(echo "$${{ matrix.test-command }}" | sed 's/[^a-zA-Z0-9]/_/g')
+          echo "TEST_CMD_ID=$TEST_CMD_ID" >> $GITHUB_ENV
+
+      - name: Upload Functional Test Coverage Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          include-hidden-files: true
+          if-no-files-found: ignore
+          name: coverage-functional-$${{ env.SYSTEM_ARCH }}
+          path: .coverage-functional
+
       # Save output for debugging
 
       - name: Generate debugging information
@@ -217,3 +241,56 @@ jobs:
         with:
           name: "juju-crashdumps-$${{ env.CRASHDUMPS_ARTEFACT_SUFFIX }}"
           path: "$${{ env.CRASHDUMPS_DIR }}/juju-crashdump-*.tar.xz"
+
+  tics-analysis:
+    runs-on: ubuntu-24.04
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    needs: func
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install coverage tools
+        run: |
+          pip install coverage
+
+      - name: Determine system architecture
+        run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
+
+      - name: Download Coverage Files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*-$${{ env.SYSTEM_ARCH }}
+          merge-multiple: true
+          path: artifacts/
+        continue-on-error: true
+
+      - name: Merge coverage reports
+        run: |
+          # Create the path that is expected to have a coverage.xml for tics
+          mkdir -p tests/report/
+
+          coverage_files=./artifacts/.coverage*
+
+          if [ -n "$coverage_files" ]; then
+            echo "Merging coverage files: $coverage_files"
+            coverage combine $coverage_files
+            coverage xml -o tests/report/coverage.xml
+          else
+            echo "No coverage files found, skipping merge"
+            # Create an empty file to avoid downstream failure
+            touch tests/report/coverage.xml
+          fi
+
+      - name: Run TICS analysis
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: ${project}
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          branchdir: $${{ github.workspace }}
+          ticsAuthToken: $${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/terraform-plans/templates/github/gitignore.tftpl
+++ b/terraform-plans/templates/github/gitignore.tftpl
@@ -11,7 +11,7 @@ __pycache__/
 
 # Test files and directories
 .pytest_cache/
-.coverage
+.coverage*
 .tox
 reports/
 **/report/


### PR DESCRIPTION
Identitical with #149, this adds tics integration for charm projects.

A POC can be found here: https://github.com/canonical/hardware-observer-operator/pull/403

- use self-hosted runner for tics to [reduce overhead](https://docs.google.com/document/d/1PRi8F-8IAPCtESDB_qN9HGyvq5t4tHFdJkG8Bu7WRak/edit?tab=t.0#heading=h.uww97wqcz7zi) introduced by a new TICS artifactory installation