### PR TITLE
Add Python 3.12 into metrics for charm-logrotated

### DIFF
--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -20,7 +20,7 @@ templates = {
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",
-      python_versions    = "['3.8', '3.10']",
+      python_versions    = "['3.8', '3.10', '3.12']",
     }
   }
   promote = {


### PR DESCRIPTION
Add Python 3.12 into metrics for [charm-logrotated](https://github.com/canonical/charm-logrotated/issues/60) when running unit test and lint 