### PR TITLE
Add extra_steps that is need for tests in COU and juju-backup-all

### DIFF
--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      python_versions  = "['3.10']",
-      tics_project     = "charmed-openstack-exporter-snap"
-      needs_juju       = ""
+      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      python_versions = "['3.10']",
+      tics_project    = "charmed-openstack-exporter-snap"
+      needs_juju      = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions = "['3.10']",
       tics_project    = "charmed-openstack-exporter-snap"
+      extra_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions = "['3.10']",
       tics_project    = "charmed-openstack-exporter-snap"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions  = "['3.10']",
       tics_project     = "charmed-openstack-exporter-snap"
-      extra_func_steps = ""
+      needs_juju       = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      python_versions = "['3.10']",
-      tics_project    = "charmed-openstack-exporter-snap"
-      extra_func_steps     = ""
+      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      python_versions  = "['3.10']",
+      tics_project     = "charmed-openstack-exporter-snap"
+      extra_func_steps = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04]]",
       tics_project    = "charmed-openstack-upgrader"
-      extra_steps     = <<EOT
+      extra_func_steps     = <<EOT
       - name: Setup Juju 3.6/stable environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions = "['3.10']",
-      runs_on         = "[[ubuntu-22.04]]",
-      tics_project    = "charmed-openstack-upgrader"
-      extra_func_steps     = <<EOT
+      python_versions  = "['3.10']",
+      runs_on          = "[[ubuntu-22.04]]",
+      tics_project     = "charmed-openstack-upgrader"
+      extra_func_steps = <<EOT
       - name: Setup Juju 3.6/stable environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -24,13 +24,7 @@ templates = {
       python_versions  = "['3.10']",
       runs_on          = "[[ubuntu-22.04]]",
       tics_project     = "charmed-openstack-upgrader"
-      extra_func_steps = <<EOT
-      - name: Setup Juju 3.6/stable environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-          juju-channel: 3.6/stable
-      EOT
+      needs_juju       = "true"
     }
   }
   promote = {

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -24,6 +24,13 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04]]",
       tics_project    = "charmed-openstack-upgrader"
+      extra_steps     = <<EOT
+      - name: Setup Juju 3.6/stable environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: 3.6/stable
+      EOT
     }
   }
   promote = {

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions  = "['3.10']",
-      runs_on          = "[[ubuntu-22.04]]",
-      tics_project     = "charmed-openstack-upgrader"
-      needs_juju       = "true"
+      python_versions = "['3.10']",
+      runs_on         = "[[ubuntu-22.04]]",
+      tics_project    = "charmed-openstack-upgrader"
+      needs_juju      = "true"
     }
   }
   promote = {

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions = "['3.10']",
       tics_project    = "dcgm-snap"
+      extra_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      python_versions = "['3.10']",
-      tics_project    = "dcgm-snap"
-      extra_func_steps     = ""
+      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      python_versions  = "['3.10']",
+      tics_project     = "dcgm-snap"
+      extra_func_steps = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions = "['3.10']",
       tics_project    = "dcgm-snap"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      python_versions  = "['3.10']",
-      tics_project     = "dcgm-snap"
-      needs_juju       = ""
+      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      python_versions = "['3.10']",
+      tics_project    = "dcgm-snap"
+      needs_juju      = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions  = "['3.10']",
       tics_project     = "dcgm-snap"
-      extra_func_steps = ""
+      needs_juju       = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      python_versions = "['3.10']",
-      tics_project    = "derper-snap"
-      extra_func_steps     = ""
+      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      python_versions  = "['3.10']",
+      tics_project     = "derper-snap"
+      extra_func_steps = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions = "['3.10']",
       tics_project    = "derper-snap"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions = "['3.10']",
       tics_project    = "derper-snap"
+      extra_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       python_versions  = "['3.10']",
       tics_project     = "derper-snap"
-      extra_func_steps = ""
+      needs_juju       = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      python_versions  = "['3.10']",
-      tics_project     = "derper-snap"
-      needs_juju       = ""
+      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      python_versions = "['3.10']",
+      tics_project    = "derper-snap"
+      needs_juju      = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project    = "headscale-snap"
+      extra_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions  = "['3.10']",
-      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      tics_project     = "headscale-snap"
-      needs_juju       = ""
+      python_versions = "['3.10']",
+      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      tics_project    = "headscale-snap"
+      needs_juju      = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions  = "['3.10']",
       runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project     = "headscale-snap"
-      extra_func_steps = ""
+      needs_juju       = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions = "['3.10']",
-      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      tics_project    = "headscale-snap"
-      extra_func_steps     = ""
+      python_versions  = "['3.10']",
+      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      tics_project     = "headscale-snap"
+      extra_func_steps = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project    = "headscale-snap"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions  = "['3.8', '3.10', '3.12']",
-      runs_on          = "[[ubuntu-24.04]]",
-      tics_project     = "juju-backup-all"
-      needs_juju       = "true"
+      python_versions = "['3.8', '3.10', '3.12']",
+      runs_on         = "[[ubuntu-24.04]]",
+      tics_project    = "juju-backup-all"
+      needs_juju      = "true"
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[['self-hosted', 'linux', 'x64', 'large', 'jammy']]",
       tics_project    = "juju-backup-all"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -21,10 +21,16 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions  = "['3.10']",
-      runs_on          = "[['self-hosted', 'linux', 'x64', 'large', 'jammy']]",
+      python_versions  = "['3.8', '3.10', '3.12']",
+      runs_on          = "[[ubuntu-24.04]]",
       tics_project     = "juju-backup-all"
-      extra_func_steps = ""
+      extra_func_steps = <<EOT
+      - name: Setup Juju 3.6/stable environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: 3.6/stable
+      EOT
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[['self-hosted', 'linux', 'x64', 'large', 'jammy']]",
       tics_project    = "juju-backup-all"
+      extra_steps     = ""
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions = "['3.10']",
-      runs_on         = "[['self-hosted', 'linux', 'x64', 'large', 'jammy']]",
-      tics_project    = "juju-backup-all"
-      extra_func_steps     = ""
+      python_versions  = "['3.10']",
+      runs_on          = "[['self-hosted', 'linux', 'x64', 'large', 'jammy']]",
+      tics_project     = "juju-backup-all"
+      extra_func_steps = ""
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -24,13 +24,7 @@ templates = {
       python_versions  = "['3.8', '3.10', '3.12']",
       runs_on          = "[[ubuntu-24.04]]",
       tics_project     = "juju-backup-all"
-      extra_func_steps = <<EOT
-      - name: Setup Juju 3.6/stable environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-          juju-channel: 3.6/stable
-      EOT
+      needs_juju       = "true"
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04]]",
       tics_project    = "prometheus-juju-backup-all-exporter"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions  = "['3.10']",
       runs_on          = "[[ubuntu-22.04]]",
       tics_project     = "prometheus-juju-backup-all-exporter"
-      extra_func_steps = ""
+      needs_juju       = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions  = "['3.10']",
-      runs_on          = "[[ubuntu-22.04]]",
-      tics_project     = "prometheus-juju-backup-all-exporter"
-      needs_juju       = ""
+      python_versions = "['3.10']",
+      runs_on         = "[[ubuntu-22.04]]",
+      tics_project    = "prometheus-juju-backup-all-exporter"
+      needs_juju      = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04]]",
       tics_project    = "prometheus-juju-backup-all-exporter"
+      extra_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions = "['3.10']",
-      runs_on         = "[[ubuntu-22.04]]",
-      tics_project    = "prometheus-juju-backup-all-exporter"
-      extra_func_steps     = ""
+      python_versions  = "['3.10']",
+      runs_on          = "[[ubuntu-22.04]]",
+      tics_project     = "prometheus-juju-backup-all-exporter"
+      extra_func_steps = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions  = "['3.10']",
       runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project     = "prometheus-openstack-exporter"
-      extra_func_steps = ""
+      needs_juju       = ""
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions  = "['3.10']",
-      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      tics_project     = "prometheus-openstack-exporter"
-      needs_juju       = ""
+      python_versions = "['3.10']",
+      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      tics_project    = "prometheus-openstack-exporter"
+      needs_juju      = ""
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project    = "prometheus-openstack-exporter"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project    = "prometheus-openstack-exporter"
+      extra_steps     = ""
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions = "['3.10']",
-      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      tics_project    = "prometheus-openstack-exporter"
-      extra_func_steps     = ""
+      python_versions  = "['3.10']",
+      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      tics_project     = "prometheus-openstack-exporter"
+      extra_func_steps = ""
     }
   }
   jira_sync_config = {

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions = "['3.10']",
-      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      tics_project    = "smartctl-exporter-snap"
-      extra_func_steps     = ""
+      python_versions  = "['3.10']",
+      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      tics_project     = "smartctl-exporter-snap"
+      extra_func_steps = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project    = "smartctl-exporter-snap"
+      extra_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project    = "smartctl-exporter-snap"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions  = "['3.10']",
       runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project     = "smartctl-exporter-snap"
-      extra_func_steps = ""
+      needs_juju       = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions  = "['3.10']",
-      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      tics_project     = "smartctl-exporter-snap"
-      needs_juju       = ""
+      python_versions = "['3.10']",
+      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      tics_project    = "smartctl-exporter-snap"
+      needs_juju      = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions = "['3.10']",
-      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      tics_project    = "tailscale-snap"
-      extra_func_steps     = ""
+      python_versions  = "['3.10']",
+      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      tics_project     = "tailscale-snap"
+      extra_func_steps = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -24,6 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project    = "tailscale-snap"
+      extra_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/snap_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      python_versions  = "['3.10']",
-      runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      tics_project     = "tailscale-snap"
-      needs_juju       = ""
+      python_versions = "['3.10']",
+      runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
+      tics_project    = "tailscale-snap"
+      needs_juju      = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions = "['3.10']",
       runs_on         = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project    = "tailscale-snap"
-      extra_steps     = ""
+      extra_func_steps     = ""
     }
   }
   promote = {

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       python_versions  = "['3.10']",
       runs_on          = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
       tics_project     = "tailscale-snap"
-      extra_func_steps = ""
+      needs_juju       = ""
     }
   }
   promote = {

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -135,8 +135,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-%{ if extra_steps != "" }
-${indent(6, chomp(extra_steps))}
+%{ if extra_func_steps != "" }
+${indent(6, chomp(extra_func_steps))}
 %{ endif }
       - name: Install dependencies
         run: |

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -137,7 +137,7 @@ jobs:
           python-version: "3.10"
 
 %{ if needs_juju == "true" ~}
-        - name: Setup Juju 3.6/stable environment
+      - name: Setup Juju 3.6/stable environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -135,7 +135,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-
+%{ if extra_steps != "" }
+${indent(6, chomp(extra_steps))}
+%{ endif }
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -135,9 +135,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-%{ if extra_func_steps != "" }
-${indent(6, chomp(extra_func_steps))}
-%{ endif }
+
+%{ if needs_juju == "true" ~}
+        - name: Setup Juju 3.6/stable environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: 3.6/stable
+
+%{ endif ~}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
COU and juju-backup-all has a special case that an extra step is needed to run the functional tess.

This change adds the `needs_juju` that can be added to add the necessary extra step.

The intention is trying to keep a single template for all projects, including COU and this will make easier for future changes or integrations.

See:
Expected [COU workflow](https://github.com/canonical/solutions-engineering-automation/actions/runs/13907380260/job/38913506913?pr=177#step:6:322)
[Example](https://github.com/canonical/solutions-engineering-automation/actions/runs/13907380260/job/38913516455?pr=177#step:6:327) of workflow of project that is not necessary an extra step