### PR TITLE
Fix the logic when there is no coverage files

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -275,9 +275,9 @@ jobs:
 
           coverage_files=(./artifacts/.coverage*)
 
-          if [ -e "${coverage_files[0]}" ]; then
-            echo "Merging coverage files: ${coverage_files[*]}"
-            coverage combine "${coverage_files[@]}"
+          if [ -e "$${coverage_files[0]}" ]; then
+            echo "Merging coverage files: $${coverage_files[*]}"
+            coverage combine "$${coverage_files[@]}"
             coverage xml -o tests/report/coverage.xml
           else
             echo "No coverage files found, skipping merge"

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -202,7 +202,7 @@ jobs:
         with:
           include-hidden-files: true
           if-no-files-found: ignore
-          name: coverage-functional-${{ env.TEST_CMD_ID }}-${{ env.SYSTEM_ARCH }}
+          name: coverage-functional-$${{ env.TEST_CMD_ID }}-$${{ env.SYSTEM_ARCH }}
           path: .coverage-func
 
       # Save output for debugging
@@ -273,7 +273,7 @@ jobs:
           # Create the path that is expected to have a coverage.xml for tics
           mkdir -p tests/report/
 
-          coverage_files=./artifacts/.coverage*
+          coverage_files=(./artifacts/.coverage*)
 
           if [ -e "${coverage_files[0]}" ]; then
             echo "Merging coverage files: ${coverage_files[*]}"

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -202,7 +202,7 @@ jobs:
         with:
           include-hidden-files: true
           if-no-files-found: ignore
-          name: coverage-functional-$${{ env.SYSTEM_ARCH }}
+          name: coverage-functional-${{ env.TEST_CMD_ID }}-${{ env.SYSTEM_ARCH }}
           path: .coverage-func
 
       # Save output for debugging
@@ -275,9 +275,9 @@ jobs:
 
           coverage_files=./artifacts/.coverage*
 
-          if [ -n "$coverage_files" ]; then
-            echo "Merging coverage files: $coverage_files"
-            coverage combine $coverage_files
+          if [ -e "${coverage_files[0]}" ]; then
+            echo "Merging coverage files: ${coverage_files[*]}"
+            coverage combine "${coverage_files[@]}"
             coverage xml -o tests/report/coverage.xml
           else
             echo "No coverage files found, skipping merge"

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -186,11 +186,11 @@ jobs:
           # Create the path that is expected to have a coverage.xml for tics
           mkdir -p tests/report/
 
-          coverage_files=./artifacts/.coverage*
+          coverage_files=(./artifacts/.coverage*)
 
-          if [ -n "$coverage_files" ]; then
-            echo "Merging coverage files: $coverage_files"
-            coverage combine $coverage_files
+          if [ -e "${coverage_files[0]}" ]; then
+            echo "Merging coverage files: ${coverage_files[*]}"
+            coverage combine "${coverage_files[@]}"
             coverage xml -o tests/report/coverage.xml
           else
             echo "No coverage files found, skipping merge"

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -188,9 +188,9 @@ jobs:
 
           coverage_files=(./artifacts/.coverage*)
 
-          if [ -e "${coverage_files[0]}" ]; then
-            echo "Merging coverage files: ${coverage_files[*]}"
-            coverage combine "${coverage_files[@]}"
+          if [ -e "$${coverage_files[0]}" ]; then
+            echo "Merging coverage files: $${coverage_files[*]}"
+            coverage combine "$${coverage_files[@]}"
             coverage xml -o tests/report/coverage.xml
           else
             echo "No coverage files found, skipping merge"


### PR DESCRIPTION
- the logic when there is no coverage files were failing because `coverage_files=./artifacts/.coverage*` always contains the wildcard as a string rather than expanding to actual files.
- include the missing env.TEST_CMD_ID for charms because functional tests can have multiple commands and artifacts cannot have the same name

A POC that this change is working can be found at https://github.com/canonical/charm-prometheus-blackbox-exporter/pull/34 that was one of the projects that were failing because of this