### PR TITLE
Temporarily disable mypy in tox.ini

### DIFF
--- a/terraform-plans/templates/github/tox.ini.tftpl
+++ b/terraform-plans/templates/github/tox.ini.tftpl
@@ -23,7 +23,8 @@ commands =
     isort --check --diff --color .
     flake8
     pylint --recursive=y .
-    mypy --install-types --non-interactive .
+    # mypy temporarily disabled because it doesn't gracefully recursively find files like the others
+    #mypy --install-types --non-interactive .
 deps =
     black
     colorama
@@ -33,7 +34,7 @@ deps =
     flake8-import-order
     flake8-pyproject
     isort
-    mypy
+    #mypy
     pep8-naming
     pylint
     # so pylint and mypy can reason about the code


### PR DESCRIPTION
It doesn't play nice if there are no py files find at the path, so we can't hardcode this for all repos.
We need to figure out a solution, but I don't think it's high priority, so let's disable it temporarily now to unblock things.