### PR TITLE
Add notification on release job failure

### DIFF
--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -55,16 +55,17 @@ jobs:
           script: |
             const failedJobs = $${{ toJSON(needs) }};
             let failedJobNames = Object.keys(failedJobs).filter(job => failedJobs[job].result === 'failure');
+            const body = [
+              "# Release workflow: $${{ github.workflow }} failed!",
+              "**Failed jobs**: " + (failedJobNames.join(', ') || 'unknown'),
+              "**Check details**: [View run]($${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }})",
+              "@canonical/solutions-engineering"
+            ].join('\n');
             await github.rest.repos.createCommitComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
-              body: `
-                Release workflow \`$${{ github.workflow }}\` failed!
-                Failed jobs: $${failedJobNames.join(', ') || 'unknown'}
-                Check details: $${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }}
-                @canonical/solutions-engineering
-              `
+              body: body
             });
         env:
           GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}

--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -41,3 +41,30 @@ jobs:
           credentials: "$${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "$${{ secrets.GITHUB_TOKEN }}"
           built-charm-path: "$${{ env.CHARM_NAMES }}"
+
+  notify-on-release-failure:
+    runs-on: ubuntu-latest
+    needs:
+      - check
+      - release
+    if: failure()
+    steps:
+      - name: Comment on commit if release workflow fails
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const failedJobs = $${{ toJSON(needs) }};
+            let failedJobNames = Object.keys(failedJobs).filter(job => failedJobs[job].result === 'failure');
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: `
+                Release workflow \`$${{ github.workflow }}\` failed!
+                Failed jobs: $${failedJobNames.join(', ') || 'unknown'}
+                Check details: $${{ github.server_url }}/$${{ github.repository }}/actions/runs/${{ github.run_id }}
+                @canonical/solutions-engineering
+              `
+            });
+        env:
+          GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}

--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -62,7 +62,7 @@ jobs:
               body: `
                 Release workflow \`$${{ github.workflow }}\` failed!
                 Failed jobs: $${failedJobNames.join(', ') || 'unknown'}
-                Check details: $${{ github.server_url }}/$${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Check details: $${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }}
                 @canonical/solutions-engineering
               `
             });

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -60,16 +60,17 @@ jobs:
           script: |
             const failedJobs = $${{ toJSON(needs) }};
             let failedJobNames = Object.keys(failedJobs).filter(job => failedJobs[job].result === 'failure');
+            const body = [
+              "# Release workflow: $${{ github.workflow }} failed!",
+              "**Failed jobs**: " + (failedJobNames.join(', ') || 'unknown'),
+              "**Check details**: [View run]($${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }})",
+              "@canonical/solutions-engineering"
+            ].join('\n');
             await github.rest.repos.createCommitComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
-              body: `
-                Release workflow \`$${{ github.workflow }}\` failed!
-                Failed jobs: $${failedJobNames.join(', ') || 'unknown'}
-                Check details: $${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }}
-                @canonical/solutions-engineering
-              `
+              body: body
             });
         env:
           GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -46,3 +46,30 @@ jobs:
           snap: $${{ env.SNAP_FILE }}
           # Comma-separated list of channels to release the snap to.
           release: ${channels}
+
+  notify-on-release-failure:
+    runs-on: ubuntu-latest
+    needs:
+      - check
+      - release
+    if: failure()
+    steps:
+      - name: Comment on commit if release workflow fails
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const failedJobs = $${{ toJSON(needs) }};
+            let failedJobNames = Object.keys(failedJobs).filter(job => failedJobs[job].result === 'failure');
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: `
+                Release workflow \`$${{ github.workflow }}\` failed!
+                Failed jobs: $${failedJobNames.join(', ') || 'unknown'}
+                Check details: $${{ github.server_url }}/$${{ github.repository }}/actions/runs/${{ github.run_id }}
+                @canonical/solutions-engineering
+              `
+            });
+        env:
+          GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -67,7 +67,7 @@ jobs:
               body: `
                 Release workflow \`$${{ github.workflow }}\` failed!
                 Failed jobs: $${failedJobNames.join(', ') || 'unknown'}
-                Check details: $${{ github.server_url }}/$${{ github.repository }}/actions/runs/${{ github.run_id }}
+                Check details: $${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }}
                 @canonical/solutions-engineering
               `
             });


### PR DESCRIPTION
This introduces a 'notify-on-release-failure' job that posts a commit comment if the release process fails. By alerting maintainers early when the release process is blocked, this ensures faster response times to fix issues, preventing delays in snap and charm publishing and improves overall release reliability.

A POC with the content of the message can be found [here](https://github.com/gabrielcocenza/charmed-openstack-exporter-snap/commit/f618ca0a9b5c614b230821b47f1e3578468427a1)