### PR TITLE
fix: Add --cov-fail-under=0 to tox functional test command

### DIFF
--- a/terraform-plans/templates/github/tox.ini.tftpl
+++ b/terraform-plans/templates/github/tox.ini.tftpl
@@ -102,6 +102,7 @@ commands = pytest {toxinidir}/tests/functional \
    --cov-report=term-missing \
    --cov-report=html \
    --cov-report=xml \
+   --cov-fail-under=0 \
    {posargs}
 %{ else ~}
 ERROR: invalid `functest_type` value


### PR DESCRIPTION
Because making functional test 100% coverage is hard for us now, we take one step back to only show the coverage