### PR TITLE
fix: Options to have requirements.txt as dep in tox.ini

### DIFF
--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "none"
+      functest_type         = "zaza"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -74,8 +74,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -74,8 +74,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "none"
+      functest_type         = "zaza"
+      unittest_type         = "none"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -67,8 +67,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -74,8 +74,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-simple-streams_main.tfvars
+++ b/terraform-plans/configs/charm-simple-streams_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -74,8 +74,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -68,8 +68,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type         = "none"
+      unittest_type         = "none"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type         = "none"
+      unittest_type         = "none"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -53,8 +53,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/juju-lint_main.tfvars
+++ b/terraform-plans/configs/juju-lint_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/layer-beats-base_main.tfvars
+++ b/terraform-plans/configs/layer-beats-base_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "pytest"
+      functest_type         = "none"
+      unittest_type         = "pytest"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/layer-filebeat_main.tfvars
+++ b/terraform-plans/configs/layer-filebeat_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type         = "none"
+      unittest_type         = "none"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/openstack-exporter-operator_main.tfvars
+++ b/terraform-plans/configs/openstack-exporter-operator_main.tfvars
@@ -63,8 +63,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type         = "zaza"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -68,8 +68,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -66,8 +66,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type         = "pytest"
+      unittest_type         = "pytest"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -53,8 +53,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type         = "none"
+      unittest_type         = "none"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_main.tfvars
+++ b/terraform-plans/configs/snap-tempest_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_antelope.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_antelope.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_bobcat.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_bobcat.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_caracal.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_caracal.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_ussuri.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_ussuri.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_victoria.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_victoria.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_wallaby.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_wallaby.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_xena.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_xena.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_yoga.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_yoga.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_stable_zed.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_zed.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type         = "pytest"
+      unittest_type         = "none"
+      root_requirements_txt = "no"
+      unit_requirements_txt = "no"
+      func_requirements_txt = "no"
     }
   }
 }

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type         = "none"
+      unittest_type         = "none"
+      root_requirements_txt = "yes"
+      unit_requirements_txt = "yes"
+      func_requirements_txt = "yes"
     }
   }
 }

--- a/terraform-plans/templates/github/tox.ini.tftpl
+++ b/terraform-plans/templates/github/tox.ini.tftpl
@@ -38,8 +38,12 @@ deps =
     pep8-naming
     pylint
     # so pylint and mypy can reason about the code
+%{ if unittest_type != "none" ~}
     {[testenv:unit]deps}
+%{ endif ~}
+%{ if functest_type != "none" ~}
     {[testenv:func]deps}
+%{ endif ~}
 
 [testenv:reformat]
 commands =
@@ -70,8 +74,12 @@ commands = pytest {toxinidir}/tests/unit \
 deps =
   pytest
   pytest-cov
+%{ if root_requirements_txt == "yes" ~}
   -r {toxinidir}/requirements.txt
+%{ endif ~}
+%{ if unittest_type != "none" && unit_requirements_txt == "yes" ~}
   -r {toxinidir}/tests/unit/requirements.txt
+%{ endif ~}
 %{ else ~}
 ERROR: invalid `unittest_type` value
 %{ endif ~}
@@ -90,8 +98,12 @@ deps =
   pytest
   pytest-cov
   pytest-operator
+%{ if root_requirements_txt == "yes" ~}
   -r {toxinidir}/requirements.txt
+%{ endif ~}
+%{ if functest_type != "none" && func_requirements_txt == "yes" ~}
   -r {toxinidir}/tests/functional/requirements.txt
+%{ endif ~}
 %{ if functest_type == "zaza" ~}
 changedir = {toxinidir}/tests/functional
 commands = functest-run-suite {posargs:--keep-model}


### PR DESCRIPTION
Provide options to include requirements.txt as dependency in tox.ini.

- root_requirements_txt: include in project's `./`
- unit_requirements_txt: include in prject's `./tests/unit`
- func_requirements_txt: include in prject's `./tests/func`
- Ignore dep when test type is none in lint testenv.