### PR TITLE
fix: linter & dependency issues on tox.ini template

### DIFF
--- a/terraform-plans/configs/charm-advanced-routing_main.tfvars
+++ b/terraform-plans/configs/charm-advanced-routing_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-apt-mirror_main.tfvars
+++ b/terraform-plans/configs/charm-apt-mirror_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-cloudsupport_main.tfvars
+++ b/terraform-plans/configs/charm-cloudsupport_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/charm-juju-backup-all_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "none"
+      functest_type     = "zaza"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -74,8 +74,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-logrotated_main.tfvars
+++ b/terraform-plans/configs/charm-logrotated_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-nginx_main.tfvars
+++ b/terraform-plans/configs/charm-nginx_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -74,8 +74,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "none"
+      functest_type     = "zaza"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-juju-exporter_main.tfvars
@@ -67,8 +67,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -74,8 +74,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-simple-streams_main.tfvars
+++ b/terraform-plans/configs/charm-simple-streams_main.tfvars
@@ -53,8 +53,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   release = {

--- a/terraform-plans/configs/charm-storage-connector_main.tfvars
+++ b/terraform-plans/configs/charm-storage-connector_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -74,8 +74,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-exporter-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
+++ b/terraform-plans/configs/charmed-openstack-upgrader_main.tfvars
@@ -68,8 +68,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/derper-snap_main.tfvars
+++ b/terraform-plans/configs/derper-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type     = "none"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -69,8 +69,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/headscale-snap_main.tfvars
+++ b/terraform-plans/configs/headscale-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type     = "none"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/juju-backup-all_main.tfvars
+++ b/terraform-plans/configs/juju-backup-all_main.tfvars
@@ -53,8 +53,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   release = {

--- a/terraform-plans/configs/juju-lint_main.tfvars
+++ b/terraform-plans/configs/juju-lint_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   release = {

--- a/terraform-plans/configs/layer-beats-base_main.tfvars
+++ b/terraform-plans/configs/layer-beats-base_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "pytest"
+      functest_type     = "none"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # layer does not need a release template

--- a/terraform-plans/configs/layer-filebeat_main.tfvars
+++ b/terraform-plans/configs/layer-filebeat_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type     = "none"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # layer does not need a release template

--- a/terraform-plans/configs/openstack-exporter-operator_main.tfvars
+++ b/terraform-plans/configs/openstack-exporter-operator_main.tfvars
@@ -70,8 +70,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "zaza"
-      unittest_type = "pytest"
+      functest_type     = "zaza"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-hardware-exporter_main.tfvars
@@ -53,8 +53,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # this python package does not need a release template

--- a/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-backup-all-exporter_main.tfvars
@@ -68,8 +68,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-juju-exporter_main.tfvars
@@ -66,8 +66,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "pytest"
+      functest_type     = "pytest"
+      unittest_type     = "pytest"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
+++ b/terraform-plans/configs/prometheus-openstack-exporter_main.tfvars
@@ -53,8 +53,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type     = "none"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # Snap under maintenance mode. No need of release

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/configs/snap-tempest_main.tfvars
+++ b/terraform-plans/configs/snap-tempest_main.tfvars
@@ -43,8 +43,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_antelope.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_antelope.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_bobcat.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_bobcat.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_caracal.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_caracal.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_ussuri.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_ussuri.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_victoria.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_victoria.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_wallaby.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_wallaby.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_xena.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_xena.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_yoga.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_yoga.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/snap-tempest_stable_zed.tfvars
+++ b/terraform-plans/configs/snap-tempest_stable_zed.tfvars
@@ -28,8 +28,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "pytest"
-      unittest_type = "none"
+      functest_type     = "pytest"
+      unittest_type     = "none"
+      is_python_project = "false"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
   # release is done by launchpad

--- a/terraform-plans/configs/tailscale-snap_main.tfvars
+++ b/terraform-plans/configs/tailscale-snap_main.tfvars
@@ -73,8 +73,11 @@ templates = {
     source      = "./templates/github/tox.ini.tftpl"
     destination = "tox.ini"
     vars = {
-      functest_type = "none"
-      unittest_type = "none"
+      functest_type     = "none"
+      unittest_type     = "none"
+      is_python_project = "true"
+      enable_pylint     = "false"
+      enable_mypy       = "false"
     }
   }
 }

--- a/terraform-plans/templates/github/tox.ini.tftpl
+++ b/terraform-plans/templates/github/tox.ini.tftpl
@@ -22,10 +22,10 @@ commands =
     black --check --diff --color .
     isort --check --diff --color .
     flake8
-%{ if enable_pylint == "yes" ~}
+%{ if enable_pylint == "true" ~}
     pylint --recursive=y .
 %{ endif ~}
-%{ if enable_mypy == "yes" ~}
+%{ if enable_mypy == "true" ~}
     mypy --install-types --non-interactive .
 %{ endif ~}
 deps =
@@ -37,11 +37,11 @@ deps =
     flake8-import-order
     flake8-pyproject
     isort
-%{ if enable_mypy == "yes" ~}
+%{ if enable_mypy == "true" ~}
     mypy
 %{ endif ~}
     pep8-naming
-%{ if enable_pylint == "yes" ~}
+%{ if enable_pylint == "true" ~}
     pylint
 %{ endif ~}
     # so pylint and mypy can reason about the code
@@ -81,7 +81,7 @@ commands = pytest {toxinidir}/tests/unit \
 deps =
   pytest
   pytest-cov
-%{ if is_python_project == "yes" ~}
+%{ if is_python_project == "true" ~}
   -r {toxinidir}/requirements.txt
 %{ endif ~}
   -r {toxinidir}/tests/unit/requirements.txt
@@ -103,7 +103,7 @@ deps =
   pytest
   pytest-cov
   pytest-operator
-%{ if is_python_project == "yes" ~}
+%{ if is_python_project == "true" ~}
   -r {toxinidir}/requirements.txt
 %{ endif ~}
   -r {toxinidir}/tests/functional/requirements.txt

--- a/terraform-plans/templates/github/tox.ini.tftpl
+++ b/terraform-plans/templates/github/tox.ini.tftpl
@@ -22,9 +22,12 @@ commands =
     black --check --diff --color .
     isort --check --diff --color .
     flake8
+%{ if enable_pylint == "yes" ~}
     pylint --recursive=y .
-    # mypy temporarily disabled because it doesn't gracefully recursively find files like the others
-    #mypy --install-types --non-interactive .
+%{ endif ~}
+%{ if enable_mypy == "yes" ~}
+    mypy --install-types --non-interactive .
+%{ endif ~}
 deps =
     black
     colorama
@@ -34,12 +37,20 @@ deps =
     flake8-import-order
     flake8-pyproject
     isort
-    #mypy
+%{ if enable_mypy == "yes" ~}
+    mypy
+%{ endif ~}
     pep8-naming
+%{ if enable_pylint == "yes" ~}
     pylint
+%{ endif ~}
     # so pylint and mypy can reason about the code
+%{ if unittest_type != "none" ~}
     {[testenv:unit]deps}
+%{ endif ~}
+%{ if functest_type != "none" ~}
     {[testenv:func]deps}
+%{ endif ~}
 
 [testenv:reformat]
 commands =
@@ -70,7 +81,9 @@ commands = pytest {toxinidir}/tests/unit \
 deps =
   pytest
   pytest-cov
+%{ if is_python_project == "yes" ~}
   -r {toxinidir}/requirements.txt
+%{ endif ~}
   -r {toxinidir}/tests/unit/requirements.txt
 %{ else ~}
 ERROR: invalid `unittest_type` value
@@ -90,7 +103,9 @@ deps =
   pytest
   pytest-cov
   pytest-operator
+%{ if is_python_project == "yes" ~}
   -r {toxinidir}/requirements.txt
+%{ endif ~}
   -r {toxinidir}/tests/functional/requirements.txt
 %{ if functest_type == "zaza" ~}
 changedir = {toxinidir}/tests/functional


### PR DESCRIPTION
Fix couple issues on tox.ini:

- Options to disable pylint & mypy on tox.ini, default disable.
- Option to include requirements.txt in root directory.
- Include testenv deps only if test is not none.