### PR TITLE
functest is zaza need TEST_JUJU3 env

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -189,7 +189,6 @@ jobs:
           echo "$CHARM_PATH_FOCAL"
           $${{ matrix.test-command }}
         env:
-          TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
           TEST_JUJU_CHANNEL: $${{ matrix.juju-channel }}
 
       - name: Generate Safe Test Command Identifier by removing spaces and special characters

--- a/terraform-plans/templates/github/tox.ini.tftpl
+++ b/terraform-plans/templates/github/tox.ini.tftpl
@@ -15,6 +15,9 @@ setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/src/:{toxinidir}/reactive/:{toxinidir}/hooks/:{toxinidir}/lib/:{toxinidir}/actions:{toxinidir}/files/:{toxinidir}/files/plugins/
   # avoid state written to file during tests - see https://github.com/juju/charm-helpers/blob/85dcbeaf63b0d0f38e8cb17825985460dc2cd02d/charmhelpers/core/unitdata.py#L179-L184
   UNIT_STATE_DB = :memory:
+%{ if functest_type == "zaza" ~}
+  TEST_JUJU3 = 1
+%{ endif ~}
 passenv = *
 
 [testenv:lint]

--- a/terraform-plans/templates/github/tox.ini.tftpl
+++ b/terraform-plans/templates/github/tox.ini.tftpl
@@ -15,9 +15,7 @@ setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/src/:{toxinidir}/reactive/:{toxinidir}/hooks/:{toxinidir}/lib/:{toxinidir}/actions:{toxinidir}/files/:{toxinidir}/files/plugins/
   # avoid state written to file during tests - see https://github.com/juju/charm-helpers/blob/85dcbeaf63b0d0f38e8cb17825985460dc2cd02d/charmhelpers/core/unitdata.py#L179-L184
   UNIT_STATE_DB = :memory:
-%{ if functest_type == "zaza" ~}
   TEST_JUJU3 = 1
-%{ endif ~}
 passenv = *
 
 [testenv:lint]


### PR DESCRIPTION
See https://github.com/canonical/charmed-openstack-upgrader/actions/runs/14059451465/job/39366428374.

Change is applied to COU, this only ports the change back to automation