### PR TITLE
Add [tool.setuptools_scm] unconditionally

### DIFF
--- a/terraform-plans/templates/github/pyproject.toml.tftpl
+++ b/terraform-plans/templates/github/pyproject.toml.tftpl
@@ -4,6 +4,8 @@
 # - Open a PR with the changes.
 # - When the PR merges, the soleng-terraform bot will open a PR to the target repositories with the changes.
 
+[tool.setuptools_scm]
+
 [tool.flake8]
 max-line-length = 99
 max-doc-length = 99


### PR DESCRIPTION
I guess this will be fine to be added unconditionally, since this is only used in pure python projects, and only affect snaps that used `craftctl set version="$(python3 setup.py --version)"`

Fixes: #190 