### PR TITLE
fix: dcgm-snap is not a python project

### DIFF
--- a/terraform-plans/configs/dcgm-snap_main.tfvars
+++ b/terraform-plans/configs/dcgm-snap_main.tfvars
@@ -75,7 +75,7 @@ templates = {
     vars = {
       functest_type     = "pytest"
       unittest_type     = "none"
-      is_python_project = "true"
+      is_python_project = "false"
       enable_pylint     = "false"
       enable_mypy       = "false"
     }


### PR DESCRIPTION
Set is_python_project to false for dcgm-snap.