### PR TITLE
Add runners used for weekly tests

### DIFF
--- a/terraform-plans/modules/GitHub/settings/main.tf
+++ b/terraform-plans/modules/GitHub/settings/main.tf
@@ -48,6 +48,8 @@ resource "github_actions_repository_permissions" "repo" {
       "snapcore/*",
       "charmed-kubernetes/*",
       "tiobe/*",
+      "convictional/*",
+      "mattermost/*",
     ]
   }
 }


### PR DESCRIPTION
Weekly Tests are not running because the workflows used in the file are currently not allowed.

See: https://github.com/canonical/solutions-engineering-automation/actions/runs/14140146293