### PR TITLE
feat: add additional description to PRs created with terraform

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -130,11 +130,20 @@ jobs:
         run: |
           terraform apply ./tf.plan -no-color
 
+      - name: Create GitHub App Token
+        if: ${{ github.ref_name == 'main' && github.event_name != 'workflow_dispatch' }}
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app_id: ${{ secrets.SOLENG_APP_ID }}
+          installation_id: ${{ secrets.SOLENG_APP_INSTALLATION_ID }}
+          private_key: ${{ secrets.SOLENG_APP_PEM_FILE }}
+
       - name: Update PR description with commit info (if running from main branch)
         if: ${{ github.ref_name == 'main' && github.event_name != 'workflow_dispatch' }}
         working-directory: ./scripts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           sudo apt-get update
           sudo apt-get install -y python3 python3-pip

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -129,3 +129,34 @@ jobs:
           GITHUB_APP_PEM_FILE: ${{ secrets.SOLENG_APP_PEM_FILE }}
         run: |
           terraform apply ./tf.plan -no-color
+
+      - name: Update PR description with commit info
+        if: ${{ github.ref_name == 'main' }}
+        working-directory: ./scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-pip
+          pip3 install requests
+
+          COMMIT_SHA="${{ github.sha }}"
+
+          PR_URL=$(terraform output -raw pr_url)
+          PR_CREATED=$(terraform output -raw pr_created)
+
+          echo "Commit SHA: $COMMIT_SHA"
+          echo "PR URL: $PR_URL"
+          echo "PR Created: $PR_CREATED"
+
+          if [[ "$PR_URL" == "No PR created" ]]; then
+            echo "No PR was created — skipping PR update step."
+            exit 0
+          fi
+
+          SCRIPT_ARGS="--url $PR_URL --commit $COMMIT_SHA --token $GITHUB_TOKEN"
+          if [[ "$PR_CREATED" == "false" ]]; then
+            SCRIPT_ARGS="$SCRIPT_ARGS -a"
+          fi
+
+          python3 update-pr-desc.py $SCRIPT_ARGS

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -130,7 +130,7 @@ jobs:
         run: |
           terraform apply ./tf.plan -no-color
 
-      - name: Update PR description with commit info
+      - name: Update PR description with commit info (if running from main branch)
         if: ${{ github.ref_name == 'main' }}
         working-directory: ./scripts
         env:

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -141,7 +141,6 @@ jobs:
           pip3 install requests
 
           COMMIT_SHA="${{ github.sha }}"
-
           PR_URL=$(terraform output -raw pr_url)
           PR_CREATED=$(terraform output -raw pr_created)
 
@@ -156,7 +155,7 @@ jobs:
 
           SCRIPT_ARGS="--url $PR_URL --commit $COMMIT_SHA --token $GITHUB_TOKEN"
           if [[ "$PR_CREATED" == "false" ]]; then
-            SCRIPT_ARGS="$SCRIPT_ARGS -a"
+            SCRIPT_ARGS="$SCRIPT_ARGS --append"
           fi
 
           python3 update-pr-desc.py $SCRIPT_ARGS

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -131,7 +131,7 @@ jobs:
           terraform apply ./tf.plan -no-color
 
       - name: Update PR description with commit info (if running from main branch)
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' && github.event_name != 'workflow_dispatch' }}
         working-directory: ./scripts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
             exit 0
           fi
 
-          SCRIPT_ARGS="--url $PR_URL --commit $COMMIT_SHA --token $GITHUB_TOKEN"
+          SCRIPT_ARGS="--url $PR_URL --commit $COMMIT_SHA"
           if [[ "$PR_CREATED" == "false" ]]; then
             SCRIPT_ARGS="$SCRIPT_ARGS --append"
           fi

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -155,6 +155,7 @@ jobs:
 
           SCRIPT_ARGS="--url $PR_URL --commit $COMMIT_SHA"
           if [[ "$PR_CREATED" == "false" ]]; then
+            # If the PR_CREATED is false and the PR_URL exists, we want to append the commit info
             SCRIPT_ARGS="$SCRIPT_ARGS --append"
           fi
 

--- a/scripts/update-pr-desc.py
+++ b/scripts/update-pr-desc.py
@@ -32,11 +32,7 @@ def get_pr_body(repo: str, pr_number: int, token: str) -> Optional[str]:
         },
     )
 
-    if resp.status_code == 403 or resp.status_code == 401:
-        raise PermissionError("Request to get the PR's information was unauthorized")
-    if resp.status_code == 404:
-        raise ValueError("PR not found")
-
+    resp.raise_for_status()
     return resp.json().get("body", None)
 
 
@@ -50,12 +46,7 @@ def update_pr_body(repo: str, pr_number: int, token: str, body: str) -> None:
         json={"body": body},
     )
 
-    if resp.status_code == 403 or resp.status_code == 401:
-        raise PermissionError("Request to update the PR's information was unauthorized")
-    if resp.status_code == 404:
-        raise ValueError("PR not found")
-    if resp.status_code != 200:
-        raise ValueError(f"Failed to update the PR: {resp.json()}")
+    resp.raise_for_status()
 
 
 def get_commit_pr_url(commit: str, token: str) -> Optional[str]:
@@ -67,10 +58,7 @@ def get_commit_pr_url(commit: str, token: str) -> Optional[str]:
         },
     )
 
-    if resp.status_code == 403 or resp.status_code == 401:
-        raise PermissionError("Request to get the Commits's information was unauthorized")
-    if resp.status_code == 404:
-        raise ValueError("Commit not found")
+    resp.raise_for_status()
 
     result = resp.json()
     if not result:
@@ -158,7 +146,7 @@ def main():
             "Github token is required. Provide it by setting the GITHUB_TOKEN environment variable."
         )
 
-    update_description(args.url, args.commit, args.token, args.append)
+    update_description(args.url, args.commit, token, args.append)
 
 
 if __name__ == "__main__":

--- a/scripts/update-pr-desc.py
+++ b/scripts/update-pr-desc.py
@@ -4,6 +4,7 @@
 
 import argparse
 import logging
+import os
 import re
 from typing import Optional
 
@@ -141,7 +142,10 @@ def main():
         required=True,
         help="The Commit SHA which will be included in the PR's description",
     )
-    parser.add_argument("--token", required=True, help="Github Token to use for the authorization")
+    parser.add_argument(
+        "--token",
+        help="Github Token to use for the authorization (can also use GITHUB_TOKEN env var)",
+    )
     parser.add_argument(
         "-a",
         "--append",
@@ -151,6 +155,13 @@ def main():
     )
 
     args = parser.parse_args()
+    token = args.token or os.getenv("GITHUB_TOKEN")
+
+    if not token:
+        parser.error(
+            "Github token is required. Provide it with --token or set GITHUB_TOKEN environment variable."
+        )
+
     update_description(args.url, args.commit, args.token, args.append)
 
 

--- a/scripts/update-pr-desc.py
+++ b/scripts/update-pr-desc.py
@@ -3,14 +3,19 @@
 """The script updates the provided PR's description with the commit."""
 
 import argparse
-from typing import Any, Optional
-import requests
-import re
 import logging
+import re
+from typing import Optional
+
+import requests
 
 OWNER = "canonical"
 SOURCE_REPO = "solutions-engineering-automation"
-DEFAULT_BODY = "This is an automated pull request from https://github.com/canonical/solutions-engineering-automation to update centrally managed files."
+DEFAULT_BODY = (
+    "This is an automated pull request from "
+    "https://github.com/canonical/solutions-engineering-automation "
+    "to update centrally managed files."
+)
 
 logger = logging.getLogger("update-pr-desc")
 logging.basicConfig(level=logging.INFO)
@@ -57,9 +62,7 @@ def get_commit_pr_url(commit: str, token: str) -> Optional[str]:
         },
     )
     if resp.status_code == 403 or resp.status_code == 401:
-        raise PermissionError(
-            "Request to get the Commits's information was unauthorized"
-        )
+        raise PermissionError("Request to get the Commits's information was unauthorized")
     if resp.status_code == 404:
         raise ValueError("Commit not found")
 
@@ -94,14 +97,13 @@ def create_new_description(body: Optional[str], commit_url: str, append: bool):
         logger.warning("Commit already in the PR's description")
         return body
 
-    changelog_header = (
-        "\n\n### Changelog\n" if not append and "### Changelog" not in body else ""
-    )
+    changelog_header = "\n\n### Changelog\n" if not append and "### Changelog" not in body else ""
     new_body = f"{body.rstrip()}{changelog_header}\n- {commit_url}"
     return new_body
 
 
 def update_description(url: str, sha: str, token: str, append: bool = False):
+    """Update the PR's description with the commit URL."""
     try:
         repo, pr_number = parse_pr_url(url)
         pr_body = get_pr_body(repo, pr_number, token)
@@ -119,6 +121,7 @@ def update_description(url: str, sha: str, token: str, append: bool = False):
 
 
 def main():
+    """Run the script."""
     parser = argparse.ArgumentParser(
         prog="Update PR description",
         description="Updates the provided PR's description with the commuit",
@@ -129,9 +132,7 @@ def main():
         required=True,
         help="The Commit SHA which will be included in the PR's description",
     )
-    parser.add_argument(
-        "--token", required=True, help="Github Token to use for the authorization"
-    )
+    parser.add_argument("--token", required=True, help="Github Token to use for the authorization")
     parser.add_argument(
         "-a",
         "--append",

--- a/scripts/update-pr-desc.py
+++ b/scripts/update-pr-desc.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+"""The script updates the provided PR's description with the commit."""
+
+import argparse
+from typing import Any, Optional
+import requests
+import re
+import logging
+
+OWNER = "canonical"
+SOURCE_REPO = "solutions-engineering-automation"
+
+logger = logging.getLogger("update-pr-body")
+logging.basicConfig(level=logging.INFO)
+
+
+def get_pr_body(repo: str, pr_number: int, token: str) -> Optional[str]:
+    """Get the PR's information from the Github API."""
+    resp = requests.get(
+        f"https://api.github.com/repos/{OWNER}/{repo}/pulls/{pr_number}",
+        headers={
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    if resp.status_code == 403 or resp.status_code == 401:
+        raise PermissionError("Request to get the PR's information was unauthorized")
+    if resp.status_code == 404:
+        raise ValueError("PR not found")
+    return resp.json().get("body", None)
+
+
+def update_pr_body(repo: str, pr_number: int, token: str, body: str) -> None:
+    """Update the PR's body with the new description."""
+    resp = requests.patch(
+        f"https://api.github.com/repos/{OWNER}/{repo}/pulls/{pr_number}",
+        headers={
+            "Authorization": f"Bearer {token}",
+        },
+        json={"body": body},
+    )
+    if resp.status_code == 403 or resp.status_code == 401:
+        raise PermissionError("Request to update the PR's information was unauthorized")
+    if resp.status_code == 404:
+        raise ValueError("PR not found")
+    if resp.status_code != 200:
+        raise ValueError(f"Failed to update the PR: {resp.json()}")
+
+
+def get_commit_pr_url(commit: str, token: str) -> Optional[str]:
+    """Get the Commit's information from the Github API."""
+    resp = requests.get(
+        f"https://api.github.com/repos/{OWNER}/{SOURCE_REPO}/commits/{commit}/pulls",
+        headers={
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    if resp.status_code == 403 or resp.status_code == 401:
+        raise PermissionError(
+            "Request to get the Commits's information was unauthorized"
+        )
+    if resp.status_code == 404:
+        raise ValueError("Commit not found")
+
+    result = resp.json()
+    if not result:
+        raise ValueError("No PRs associated with this commit")
+    if len(result) > 1:
+        logger.warning("Multiple PRs found for commit. Using the first one.")
+
+    return result[0].get("html_url", None)
+
+
+def parse_pr_url(url: str) -> tuple:
+    """Parse the PR URL and return the repo and PR number."""
+    escaped_owner = re.escape(OWNER)
+    regex = re.compile(rf"github\.com\/{escaped_owner}\/([a-zA-Z-]+)\/pull\/(\d+)")
+    result = regex.search(url)
+
+    if not result or len(result.groups()) != 2:
+        raise ValueError("Invalid PR URL")
+    return result.groups()
+
+
+def create_new_description(body: str, commit_url: str, append: bool):
+    """Create a new description for the PR."""
+    if commit_url in body:
+        logger.warning("Commit already in the PR's description")
+        return body
+
+    changelog_header = (
+        "\n\n### Changelog\n" if not append and "### Changelog" not in body else ""
+    )
+    new_body = f"{body.rstrip()}{changelog_header}\n- {commit_url}"
+    return new_body
+
+
+def update_description(url: str, sha: str, token: str, append: bool = False):
+    try:
+        repo, pr_number = parse_pr_url(url)
+        pr_body = get_pr_body(repo, pr_number, token)
+        commit_pr_url = get_commit_pr_url(sha, token)
+        if not pr_body or not commit_pr_url:
+            raise ValueError("Failed to get the PR's body or the commit's PR URL")
+
+        new_desc = create_new_description(pr_body, commit_pr_url, append)
+        logger.info("New description:\n%s", new_desc)
+
+        update_pr_body(repo, pr_number, token, new_desc)
+        logger.info("Updated the PR's description successfully")
+    except Exception as e:
+        logger.error("Failed to update the description: %s", e)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="Update PR description",
+        description="Updates the provided PR's description with the commuit",
+    )
+    parser.add_argument("--url", required=True, help="URL of the PR to be updated")
+    parser.add_argument(
+        "--commit",
+        required=True,
+        help="The Commit SHA which will be included in the PR's description",
+    )
+    parser.add_argument(
+        "--token", required=True, help="Github Token to use for the authorization"
+    )
+    parser.add_argument(
+        "-a",
+        "--append",
+        default=False,
+        help="Whether to append to the existing list of commits or create it",
+        action="store_true",
+    )
+
+    args = parser.parse_args()
+    update_description(args.url, args.commit, args.token, args.append)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update-pr-desc.py
+++ b/scripts/update-pr-desc.py
@@ -143,10 +143,6 @@ def main():
         help="The Commit SHA which will be included in the PR's description",
     )
     parser.add_argument(
-        "--token",
-        help="Github Token to use for the authorization (can also use GITHUB_TOKEN env var)",
-    )
-    parser.add_argument(
         "-a",
         "--append",
         default=False,
@@ -155,11 +151,11 @@ def main():
     )
 
     args = parser.parse_args()
-    token = args.token or os.getenv("GITHUB_TOKEN")
+    token = os.getenv("GITHUB_TOKEN")
 
     if not token:
         parser.error(
-            "Github token is required. Provide it with --token or set GITHUB_TOKEN environment variable."
+            "Github token is required. Provide it by setting the GITHUB_TOKEN environment variable."
         )
 
     update_description(args.url, args.commit, args.token, args.append)


### PR DESCRIPTION
This adds a Python script that runs after the `Terraform apply` step. The script will append the created PR with the PR link from this repo, adding a changelog. 

Having a script may allow us to do other things to improve the automation, giving us more flexibility. 

We can also stick to the Terraform plan, but due to limitations, we won't be able to have a `Changelog`, which accumulates a list of the PRs on the target repos.

[Example PR description](https://github.com/Deezzir/solutions-engineering-automation/pull/1)

Closes: #105