### PR TITLE
Update charmcraft to 3.x/stable

### DIFF
--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on            = "[[ubuntu-22.04]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
-      charmcraft_channel = "2.x/stable",
+      charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
       tics_project       = "charm-duplicity"
     }

--- a/terraform-plans/configs/charm-juju-local_main.tfvars
+++ b/terraform-plans/configs/charm-juju-local_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on            = "[[ubuntu-22.04]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
-      charmcraft_channel = "2.x/stable",
+      charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
       tics_project       = ""
     }

--- a/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
+++ b/terraform-plans/configs/charm-openstack-service-checks_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on            = "[['self-hosted', 'jammy', 'amd64', 'two-xlarge']]",
       test_commands      = "[ \"TEST_MODEL_SETTINGS='update-status-hook-interval=30s' tox -e func -- --keep-model -b jammy-yoga\", \"TEST_MODEL_SETTINGS='update-status-hook-interval=30s' tox -e func -- --keep-model -b focal-yoga\" ]"
       juju_channels      = "['3.4/stable']",
-      charmcraft_channel = "2.x/stable",
+      charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
       tics_project       = "charm-openstack-service-checks"
     }

--- a/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-blackbox-exporter_main.tfvars
@@ -24,7 +24,7 @@ templates = {
       runs_on            = "[[ubuntu-22.04]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
-      charmcraft_channel = "2.x/stable",
+      charmcraft_channel = "3.x/stable",
       python_versions    = "['3.8', '3.10']",
       tics_project       = "charm-prometheus-blackbox-exporter"
     }


### PR DESCRIPTION
These repos support charmcraft 3 recently.
- https://github.com/canonical/charm-prometheus-blackbox-exporter/pull/29
- https://github.com/canonical/charm-openstack-service-checks/pull/202
- https://github.com/canonical/charm-juju-local/pull/35
- https://github.com/canonical/charm-duplicity/pull/46