### PR TITLE
Disable charm promote on projects to avoid regressions

### DIFF
--- a/terraform-plans/templates/github/charm_promote.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_promote.yaml.tftpl
@@ -8,7 +8,15 @@
 # https://github.com/canonical/charming-actions/issues/157
 # https://github.com/canonical/charmcraft/issues/2243
 
-# name: Promote charm to default track, standard risk levels.
+name: Promote charm to default track, standard risk levels.
+on:
+  workflow_dispatch:
+
+jobs:
+  disabled_notice:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This workflow is temporarily disabled. No actions will be performed."
 #
 # on:
 #   workflow_dispatch:


### PR DESCRIPTION
After the changes introduces at #197, Github complains about a workflow file without defining `on`. See one [e.g](https://github.com/canonical/hardware-observer-operator/actions/runs/14309320222) This PR adds a dummy workflow to not block GitHub and can be easily removed in the future.