### PR TITLE
Reduce coverage for charm duplicity

### DIFF
--- a/terraform-plans/configs/charm-duplicity_main.tfvars
+++ b/terraform-plans/configs/charm-duplicity_main.tfvars
@@ -62,7 +62,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "98"
+      coverage_threshold_percent = "94"
     }
   }
   tox = {

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -62,7 +62,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "91"
     }
   }
   tox = {


### PR DESCRIPTION
- https://github.com/canonical/charm-duplicity/pull/55 shows that the coverage now is only 94.92%.
- https://github.com/canonical/charm-sysconfig/pull/99 shows that  the coverage now is only 91.24%.