### PR TITLE
Support func tests on juju2.9

### DIFF
--- a/terraform-plans/templates/github/pyproject.toml.tftpl
+++ b/terraform-plans/templates/github/pyproject.toml.tftpl
@@ -63,7 +63,7 @@ exclude = '''
 [tool.isort]
 profile = "black"
 line_length = 99
-skip_glob = [".eggs", ".git", ".tox", ".venv", ".build", "build", "lib", "report", "mod", "hooks/charmhelpers", "tests/charmhelpers"]
+skip_glob = [".eggs", ".git", ".tox", ".venv", ".build", "build", "lib", "report", "mod/*", "hooks/charmhelpers", "tests/charmhelpers"]
 
 [tool.pylint]
 max-line-length = 99

--- a/terraform-plans/templates/github/tox.ini.tftpl
+++ b/terraform-plans/templates/github/tox.ini.tftpl
@@ -15,7 +15,9 @@ setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/src/:{toxinidir}/reactive/:{toxinidir}/hooks/:{toxinidir}/lib/:{toxinidir}/actions:{toxinidir}/files/:{toxinidir}/files/plugins/
   # avoid state written to file during tests - see https://github.com/juju/charm-helpers/blob/85dcbeaf63b0d0f38e8cb17825985460dc2cd02d/charmhelpers/core/unitdata.py#L179-L184
   UNIT_STATE_DB = :memory:
-  TEST_JUJU3 = 1
+  # Default to juju 3, but don't overwrite it if already set in the environment.
+  # This allows us to still test with juju2.9 for some projects by updating the env externally.
+  TEST_JUJU3 = {env:TEST_JUJU3:1}
 passenv = *
 
 [testenv:lint]


### PR DESCRIPTION
Required by https://github.com/canonical/charm-prometheus-juju-exporter/pull/86 which sets TEST_JUJU3 in the env from check.yaml
depending on which juju version is being used for the tests.

Also fix the skip glob for isort.