### PR TITLE
Fix tics for projects that doesn't generate coverage

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -275,14 +275,15 @@ jobs:
 
           coverage_files=(./artifacts/.coverage*)
 
-          if [ -e "$${coverage_files[0]}" ]; then
-            echo "Merging coverage files: $${coverage_files[*]}"
-            coverage combine "$${coverage_files[@]}"
-            coverage xml -o tests/report/coverage.xml
-          else
-            echo "No coverage files found, skipping merge"
-            # Create an empty file to avoid downstream failure
-            touch tests/report/coverage.xml
+          if [ -e "${coverage_files[0]}" ]; then
+            echo "Merging coverage files: ${coverage_files[*]}"
+            coverage combine "${coverage_files[@]}"
+
+            # Check if there is actual data to report before generating XML with merged reports
+            if coverage report > /dev/null 2>&1; then
+              coverage xml -o tests/report/coverage.xml
+            fi
+
           fi
 
       - name: Run TICS analysis

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -275,9 +275,9 @@ jobs:
 
           coverage_files=(./artifacts/.coverage*)
 
-          if [ -e "${coverage_files[0]}" ]; then
-            echo "Merging coverage files: ${coverage_files[*]}"
-            coverage combine "${coverage_files[@]}"
+          if [ -e "$${coverage_files[0]}" ]; then
+            echo "Merging coverage files: $${coverage_files[*]}"
+            coverage combine "$${coverage_files[@]}"
 
             # Check if there is actual data to report before generating XML with merged reports
             if coverage report > /dev/null 2>&1; then

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -197,14 +197,15 @@ jobs:
 
           coverage_files=(./artifacts/.coverage*)
 
-          if [ -e "$${coverage_files[0]}" ]; then
-            echo "Merging coverage files: $${coverage_files[*]}"
-            coverage combine "$${coverage_files[@]}"
-            coverage xml -o tests/report/coverage.xml
-          else
-            echo "No coverage files found, skipping merge"
-            # Create an empty file to avoid downstream failure
-            touch tests/report/coverage.xml
+          if [ -e "${coverage_files[0]}" ]; then
+            echo "Merging coverage files: ${coverage_files[*]}"
+            coverage combine "${coverage_files[@]}"
+
+            # Check if there is actual data to report before generating XML with merged reports
+            if coverage report > /dev/null 2>&1; then
+              coverage xml -o tests/report/coverage.xml
+            fi
+
           fi
 
       - name: Run TICS analysis

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -197,9 +197,9 @@ jobs:
 
           coverage_files=(./artifacts/.coverage*)
 
-          if [ -e "${coverage_files[0]}" ]; then
-            echo "Merging coverage files: ${coverage_files[*]}"
-            coverage combine "${coverage_files[@]}"
+          if [ -e "$${coverage_files[0]}" ]; then
+            echo "Merging coverage files: $${coverage_files[*]}"
+            coverage combine "$${coverage_files[@]}"
 
             # Check if there is actual data to report before generating XML with merged reports
             if coverage report > /dev/null 2>&1; then


### PR DESCRIPTION
Some projects that does not generate coverage fails the CI when trying to generate the xml report. This PR checks if the project is able to generate to not exit. See a [POC](https://github.com/canonical/charmed-openstack-exporter-snap/pull/28) that is working for this case.