### PR TITLE
Change the threshold of charm-prometheus-libvirt-exporter

### DIFF
--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -67,7 +67,7 @@ templates = {
     source      = "./templates/github/pyproject.toml.tftpl"
     destination = "pyproject.toml"
     vars = {
-      coverage_threshold_percent = "100"
+      coverage_threshold_percent = "40"
     }
   }
   tox = {


### PR DESCRIPTION
Currently the charm has 40% coverage, so setting to 100% fails the PRs from the automation tool. See https://github.com/canonical/charm-prometheus-libvirt-exporter/pull/68