### PR TITLE
Support build on ppc64el but not test on ppc64el

### DIFF
--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -27,9 +27,9 @@ templates = {
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       #
-      # Cannot test on s390x because setup-python action does not support s390x (see issue #206)
+      # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
       tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x]]",
+      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -27,9 +27,9 @@ templates = {
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       #
-      # Cannot test on s390x because setup-python action does not support s390x (see issue #206)
+      # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
       tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x]]",
+      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -27,9 +27,9 @@ templates = {
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       #
-      # Cannot test on s390x because setup-python action does not support s390x (see issue #206)
+      # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
       tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x]]",
+      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/charm-sysconfig_main.tfvars
+++ b/terraform-plans/configs/charm-sysconfig_main.tfvars
@@ -21,10 +21,10 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      # Cannot test on s390x because setup-python action does not support s390x (see issue #206)
+      # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
       # Cannot test on arm64 because charms in the test bundle does not support arm64
       tests_on           = "[[self-hosted, jammy, X64, large]]",
-      builds_on          = "[[self-hosted, jammy, X64, large], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x]]",
+      builds_on          = "[[self-hosted, jammy, X64, large], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -27,9 +27,9 @@ templates = {
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       #
-      # Cannot test on s390x because setup-python action does not support s390x (see issue #206)
+      # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
       tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x]]",
+      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -21,9 +21,9 @@ templates = {
     source      = "./templates/github/charm_check.yaml.tftpl"
     destination = ".github/workflows/check.yaml"
     vars = {
-      # Cannot test on s390x because setup-python action does not support s390x (see issue #206)
+      # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
       tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x]]",
+      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func -- -v --base ubuntu@20.04 --keep-models', 'tox -e func -- -v --base ubuntu@22.04 --keep-models', 'tox -e func -- -v --base ubuntu@24.04 --keep-models' ]",
       juju_channels      = "[\"3.4/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
+++ b/terraform-plans/configs/smartctl-exporter-snap_main.tfvars
@@ -22,9 +22,9 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars = {
       python_versions = "['3.10']",
-      # Cannot test on s390x because setup-python action does not support s390x (see issue #206)
+      # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
       tests_on     = "[[ubuntu-22.04], [self-hosted, jammy, ARM64]]",
-      builds_on    = "[[ubuntu-22.04], [self-hosted, jammy, ARM64], [self-hosted, linux, s390x]]",
+      builds_on    = "[[ubuntu-22.04], [self-hosted, jammy, ARM64], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       tics_project = "smartctl-exporter-snap"
       needs_juju   = ""
     }


### PR DESCRIPTION
- charm-local-users_main
- charm-nrpe_main
- charm-prometheus-libvirt-exporter_main
- charm-sysconfig_main
- charm-userdir-ldap_main
- hardware-observer-operator_main

Note: the runner is defined here https://github.com/canonical/cbartz-runner-testing/actions/runs/14489922080/job/40643805979