### PR TITLE
Move the coverage report --show-missing introduced in #207

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -304,10 +304,10 @@ jobs:
           if [ -e "$${coverage_files[0]}" ]; then
             echo "Merging coverage files: $${coverage_files[*]}"
             coverage combine "$${coverage_files[@]}"
-            coverage report --show-missing
 
             # Check if there is actual data to report before generating XML with merged reports
             if coverage report > /dev/null 2>&1; then
+              coverage report --show-missing
               coverage xml -o tests/report/coverage.xml
             fi
 

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -228,10 +228,10 @@ jobs:
           if [ -e "$${coverage_files[0]}" ]; then
             echo "Merging coverage files: $${coverage_files[*]}"
             coverage combine "$${coverage_files[@]}"
-            coverage report --show-missing
 
             # Check if there is actual data to report before generating XML with merged reports
             if coverage report > /dev/null 2>&1; then
+              coverage report --show-missing
               coverage xml -o tests/report/coverage.xml
             fi
 


### PR DESCRIPTION
We cannot run this command because empty reports of functional tests will exit with 1. After the check that there is actual data to report, we can print the report without issue and this can help for debugging.