### PR TITLE
Use self-hosted runners for TICS

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -284,10 +284,16 @@ jobs:
           pip install coverage
 
       # Install everything from all requirements.txt files otherwise TICS errors.
-      - name: Install all snap dependencies
+      - name: Install all charm dependencies
         run: |
           for f in $(find -name '*requirements.txt'); do
-              echo "${f}"
+              echo "$${f}"
+              pip3 install --requirement "$${f}"
+          done
+
+          # For reactive charms
+          for f in $(find -name 'wheelhouse.txt'); do
+              echo "$${f}"
               pip3 install --requirement "$${f}"
           done
 

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -269,7 +269,7 @@ jobs:
 
 %{ if tics_project != "" ~}
   tics-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
     if: >
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
@@ -282,6 +282,14 @@ jobs:
       - name: Install coverage tools
         run: |
           pip install coverage
+
+      # Install everything from all requirements.txt files otherwise TICS errors.
+      - name: Install all snap dependencies
+        run: |
+          for f in $(find -name '*requirements.txt'); do
+              echo "${f}"
+              pip3 install --requirement "$${f}"
+          done
 
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -208,16 +208,10 @@ jobs:
           pip install coverage
 
       # Install everything from all requirements.txt files otherwise TICS errors.
-      - name: Install all charm dependencies
+      - name: Install all snap dependencies
         run: |
           for f in $(find -name '*requirements.txt'); do
-              echo "${f}"
-              pip3 install --requirement "$${f}"
-          done
-
-          # For reactive charms
-          for f in $(find -name 'wheelhouse.txt'); do
-              echo "${f}"
+              echo "$${f}"
               pip3 install --requirement "$${f}"
           done
 

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -193,7 +193,7 @@ jobs:
 
 %{ if tics_project != "" ~}
   tics-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
     if: >
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
@@ -206,6 +206,20 @@ jobs:
       - name: Install coverage tools
         run: |
           pip install coverage
+
+      # Install everything from all requirements.txt files otherwise TICS errors.
+      - name: Install all charm dependencies
+        run: |
+          for f in $(find -name '*requirements.txt'); do
+              echo "${f}"
+              pip3 install --requirement "$${f}"
+          done
+
+          # For reactive charms
+          for f in $(find -name 'wheelhouse.txt'); do
+              echo "${f}"
+              pip3 install --requirement "$${f}"
+          done
 
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV


### PR DESCRIPTION
- self-hosted runners already installs pylint and flake8 that tics is complaining
- after talking with the TIOBE peole and reading the spec, it's necessary to install the charm/snap dependencies
- using the self-hosted runners and installing all the dependencies seems to fix the issues on nrpe and duplicity. See the POCs:
  - https://github.com/canonical/charm-duplicity/pull/59
  - https://github.com/canonical/charm-nrpe/pull/239

Closes: #175, #211