### PR TITLE
Add new tempest snap config to workflow

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -84,6 +84,8 @@ jobs:
             - snap-tempest_stable_xena
             - snap-tempest_stable_yoga
             - snap-tempest_stable_zed
+            - snap-tempest_stable_dalmatian
+            - snap-tempest_stable_epoxy
             - solutions-engineering-automation_main
             - tailscale-snap_main
             - headscale-snap_main


### PR DESCRIPTION
Follow on from #222, where the config files were added. They need to be configured in the terraform-apply workflow too, otherwise the config will be ignored.