### PR TITLE
Change to use MM notification on release failure

### DIFF
--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -49,23 +49,9 @@ jobs:
       - release
     if: failure()
     steps:
-      - name: Comment on commit if release workflow fails
-        uses: actions/github-script@v7
+      - name: Notify release failure
+        uses: mattermost/action-mattermost-notify@master
         with:
-          script: |
-            const failedJobs = $${{ toJSON(needs) }};
-            let failedJobNames = Object.keys(failedJobs).filter(job => failedJobs[job].result === 'failure');
-            const body = [
-              "# Release workflow: $${{ github.workflow }} failed!",
-              "**Failed jobs**: " + (failedJobNames.join(', ') || 'unknown'),
-              "**Check details**: [View run]($${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }})",
-              "@canonical/solutions-engineering"
-            ].join('\n');
-            await github.rest.repos.createCommitComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-              body: body
-            });
-        env:
-          GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: $${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          TEXT: |
+            :rotating_light: Release failed in project [$${{ github.repository }}]($${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }})

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -54,23 +54,9 @@ jobs:
       - release
     if: failure()
     steps:
-      - name: Comment on commit if release workflow fails
-        uses: actions/github-script@v7
+      - name: Notify release failure
+        uses: mattermost/action-mattermost-notify@master
         with:
-          script: |
-            const failedJobs = $${{ toJSON(needs) }};
-            let failedJobNames = Object.keys(failedJobs).filter(job => failedJobs[job].result === 'failure');
-            const body = [
-              "# Release workflow: $${{ github.workflow }} failed!",
-              "**Failed jobs**: " + (failedJobNames.join(', ') || 'unknown'),
-              "**Check details**: [View run]($${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }})",
-              "@canonical/solutions-engineering"
-            ].join('\n');
-            await github.rest.repos.createCommitComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.sha,
-              body: body
-            });
-        env:
-          GITHUB_TOKEN: $${{ secrets.GITHUB_TOKEN }}
+          MATTERMOST_WEBHOOK_URL: $${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          TEXT: |
+            :rotating_light: Release failed in project [$${{ github.repository }}]($${{ github.server_url }}/$${{ github.repository }}/actions/runs/$${{ github.run_id }})


### PR DESCRIPTION
GitHub bot doesn't have enough permissions to tag the team and create a notification. Using the MM bot we can notify on our channel when a release fails.

The `MATTERMOST_WEBHOOK_URL` was added on all our repos so the projects are ready to start notifying.

A small POC was done on https://github.com/canonical/charm-nrpe/pull/241 and the notification are working as expected.

![image](https://github.com/user-attachments/assets/5189a0c5-3516-4a4f-a7a3-fd619ab4ed26)
