### PR TITLE
Reduce noise by limiting to just one run attempt

### DIFF
--- a/terraform-plans/templates/github/charm_release.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_release.yaml.tftpl
@@ -47,7 +47,7 @@ jobs:
     needs:
       - check
       - release
-    if: failure()
+    if: $${{ failure() && github.run_attempt == 1 }}
     steps:
       - name: Notify release failure
         uses: mattermost/action-mattermost-notify@master

--- a/terraform-plans/templates/github/snap_release.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_release.yaml.tftpl
@@ -52,7 +52,7 @@ jobs:
     needs:
       - check
       - release
-    if: failure()
+    if: $${{ failure() && github.run_attempt == 1 }}
     steps:
       - name: Notify release failure
         uses: mattermost/action-mattermost-notify@master


### PR DESCRIPTION
In case a release fails a notification to the channel is made. However, if it fails again, new notifications will surge which can be noisy. Limiting to just the first attempt will avoid new alerts for the same issue

This will avoid something like it happened yesterday:

![image](https://github.com/user-attachments/assets/d5f14c2d-b8ba-4d65-9085-e885dafd0b9c)
