### PR TITLE
Exclude COS integration test for hardware-observer from weekly tests

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -39,8 +39,8 @@ jobs:
         include:
           - repo: hardware-observer-operator
             workflow_file_name: check.yaml
-          - repo: hardware-observer-operator
-            workflow_file_name: cos_integration.yaml
+          # - repo: hardware-observer-operator
+          #   workflow_file_name: cos_integration.yaml
 
     steps:
       - name: Run ${{ matrix.workflow_file_name }} tests for ${{ matrix.repo }}


### PR DESCRIPTION
This PR is to temporary remove the COS integration test for [Hardware Observer](https://github.com/canonical/hardware-observer-operator) from weekly tests.

This test keeps failing because in the Github CI environment, there are no exporters installed due to no hardware access (in[ scrape config](https://github.com/canonical/hardware-observer-operator/blob/907bb1111dd59b8f97ac087d8b921ac4492789e5/src/charm.py#L298), `self.exporters` is empty)  Therefore, `grafana-agent` related to HWO is configured without scraping anything from HWO. See these logs for verification (line 389-394): https://github.com/canonical/hardware-observer-operator/actions/runs/16584135774/job/46906104169?pr=448#step:9:390

A possible future solution is to run the workflow on a self-hosted machine with hardware access. Continuation on this [PoC](https://github.com/canonical/hardware-observer-operator/pull/431) could be a nice one. Until that, the COS integration test is removed from the weekly tests.