### PR TITLE
build: Switch to github public arm runner

### DIFF
--- a/terraform-plans/configs/charm-local-users_main.tfvars
+++ b/terraform-plans/configs/charm-local-users_main.tfvars
@@ -22,14 +22,14 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars = {
       # github hosted runners are amd64
-      # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
+      # ubuntu-24.04-arm is the github-hosted arm64 runner we have access to.
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       #
       # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
-      tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
+      tests_on           = "[[ubuntu-24.04], [ubuntu-24.04-arm]]",
+      builds_on          = "[[ubuntu-24.04], [ubuntu-24.04-arm], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.6/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/charm-nrpe_main.tfvars
+++ b/terraform-plans/configs/charm-nrpe_main.tfvars
@@ -22,14 +22,14 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars = {
       # github hosted runners are amd64
-      # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
+      # ubuntu-24.04-arm is the github-hosted arm64 runner we have access to.
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       #
       # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
-      tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
+      tests_on           = "[[ubuntu-24.04], [ubuntu-24.04-arm]]",
+      builds_on          = "[[ubuntu-24.04], [ubuntu-24.04-arm], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.6/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
+++ b/terraform-plans/configs/charm-prometheus-libvirt-exporter_main.tfvars
@@ -22,14 +22,14 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars = {
       # github hosted runners are amd64
-      # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
+      # ubuntu-24.04-arm is the github-hosted arm64 runner we have access to.
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       #
       # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
-      tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
+      tests_on           = "[[ubuntu-24.04], [ubuntu-24.04-arm]]",
+      builds_on          = "[[ubuntu-24.04], [ubuntu-24.04-arm], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.6/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/charm-userdir-ldap_main.tfvars
+++ b/terraform-plans/configs/charm-userdir-ldap_main.tfvars
@@ -22,14 +22,14 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars = {
       # github hosted runners are amd64
-      # Ubuntu_ARM64_4C_16G_01 is the github-hosted arm64 runner we have access to.
+      # ubuntu-24.04-arm is the github-hosted arm64 runner we have access to.
       # We prefer the github runners because they are smaller machines and save resources.
       # If we have issues with it, we can switch to the larger and more numerous self-hosted options:
       # - runs-on: [self-hosted, jammy, ARM64]
       #
       # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
-      tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
+      tests_on           = "[[ubuntu-24.04], [ubuntu-24.04-arm]]",
+      builds_on          = "[[ubuntu-24.04], [ubuntu-24.04-arm], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func']",
       juju_channels      = "[\"3.6/stable\"]",
       charmcraft_channel = "3.x/stable",

--- a/terraform-plans/configs/hardware-observer-operator_main.tfvars
+++ b/terraform-plans/configs/hardware-observer-operator_main.tfvars
@@ -22,8 +22,8 @@ templates = {
     destination = ".github/workflows/check.yaml"
     vars = {
       # Cannot test on s390x and ppc64el because setup-python action does not support s390x and ppc64el (see issue #206)
-      tests_on           = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01]]",
-      builds_on          = "[[ubuntu-24.04], [Ubuntu_ARM64_4C_16G_01], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
+      tests_on           = "[[ubuntu-24.04], [ubuntu-24.04-arm]]",
+      builds_on          = "[[ubuntu-24.04], [ubuntu-24.04-arm], [self-hosted, linux, s390x],[self-hosted, ppc64el]]",
       test_commands      = "['tox -e func -- -v --base ubuntu@20.04 --keep-models', 'tox -e func -- -v --base ubuntu@22.04 --keep-models', 'tox -e func -- -v --base ubuntu@24.04 --keep-models' ]",
       juju_channels      = "[\"3.6/stable\"]",
       charmcraft_channel = "3.x/stable",


### PR DESCRIPTION
Replace `Ubuntu_ARM64_4C_16G_01` with `ubuntu-24.04-arm`.

(Note: the charm-sysconfig requires large runner, it will stay on self-hosted runner)