### PR TITLE
Include timed out runs in MM notifications

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Run ${{ matrix.workflow_file_name }} tests for ${{ matrix.repo }}
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         id: dispatched-tests
+        timeout-minutes: 300 # 5 hours for the run to complete
         with:
           owner: canonical
           repo: ${{ matrix.repo }}

--- a/scripts/weekly-tests-summary.py
+++ b/scripts/weekly-tests-summary.py
@@ -19,11 +19,14 @@ def load_results() -> list[dict[str, str]]:
 
 def format_result(result: dict[str, str]) -> str:
     """Take a result and return a markdown string"""
-    icon = (
-        ":gh-success-octicon-checkcirclefillicon:"
-        if result["conclusion"] == "success"
-        else ":gh-failure-octicon-xcirclefillicon:"
-    )
+    conclusion = result["conclusion"]
+    if conclusion == "success":
+        icon = ":gh-success-octicon-checkcirclefillicon:"
+    elif conclusion == "cancelled":
+        icon = ":gh-cancelled-octicon-stopicon:"
+    else:
+        icon = ":gh-failure-octicon-xcirclefillicon:"
+
     repo = result["repo"]
     branch = result["branch"]
     workflow = result["workflow_file_name"]


### PR DESCRIPTION
The PR adds:
- a step-level `timeout-minutes` to the dispatch step so it fails/cancels gracefully before GitHub kills the entire job, leaving enough time for the cleanup steps to run.
- additional check for the run outcome with a separate icon.

Closes: #275 