### PR TITLE
install python packages in virtual env for tics-analysis job

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -279,10 +279,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install coverage tools
-        run: |
-          pip install coverage[toml]
-
       # Install everything from all requirements.txt files otherwise TICS errors.
       - name: Install all charm dependencies
         run: |
@@ -290,18 +286,18 @@ jobs:
           sudo apt update
           sudo apt install python3-venv -y
           python3 -m venv .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install coverage[toml]
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
-              pip3 install --requirement "$${f}"
+              .venv/bin/python -m pip install --requirement "$${f}"
           done
 
           # For reactive charms
           for f in $(find -name 'wheelhouse.txt'); do
               echo "$${f}"
-              pip3 install --requirement "$${f}"
+              .venv/bin/python -m pip install --requirement "$${f}"
           done
 
           echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -286,6 +286,12 @@ jobs:
       # Install everything from all requirements.txt files otherwise TICS errors.
       - name: Install all charm dependencies
         run: |
+          # run in a virtualenv to ensure dependencies will not conflict with the system python packages
+          sudo apt install python3.10-venv -y
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
               pip3 install --requirement "$${f}"

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -287,7 +287,8 @@ jobs:
       - name: Install all charm dependencies
         run: |
           # run in a virtualenv to ensure dependencies will not conflict with the system python packages
-          sudo apt install python3.10-venv -y
+          sudo apt update
+          sudo apt install python3-venv -y
           python3 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip

--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -304,6 +304,8 @@ jobs:
               pip3 install --requirement "$${f}"
           done
 
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
 

--- a/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
@@ -220,7 +220,8 @@ jobs:
           TEST_JUJU3: "1"
         run: |
           # run in a virtualenv to ensure dependencies will not conflict with the system python packages
-          sudo apt install python3.10-venv -y
+          sudo apt update
+          sudo apt install python3-venv -y
           python3 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip

--- a/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
@@ -219,6 +219,12 @@ jobs:
           # to ensure that zaza installs correctly
           TEST_JUJU3: "1"
         run: |
+          # run in a virtualenv to ensure dependencies will not conflict with the system python packages
+          sudo apt install python3.10-venv -y
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
               pip3 install --requirement "$${f}"

--- a/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
@@ -209,10 +209,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install coverage tools
-        run: |
-          pip install coverage[toml]
-
       # Install everything from all requirements.txt files otherwise TICS errors.
       - name: Install all snap dependencies
         env:
@@ -223,12 +219,12 @@ jobs:
           sudo apt update
           sudo apt install python3-venv -y
           python3 -m venv .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install coverage[toml]
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
-              pip3 install --requirement "$${f}"
+              .venv/bin/python -m pip install --requirement "$${f}"
           done
 
           echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH

--- a/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
@@ -231,6 +231,8 @@ jobs:
               pip3 install --requirement "$${f}"
           done
 
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
 

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -203,10 +203,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install coverage tools
-        run: |
-          pip install coverage[toml]
-
       # Install everything from all requirements.txt files otherwise TICS errors.
       - name: Install all snap dependencies
         env:
@@ -217,12 +213,12 @@ jobs:
           sudo apt update
           sudo apt install python3-venv -y
           python3 -m venv .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install coverage[toml]
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
-              pip3 install --requirement "$${f}"
+              .venv/bin/python -m pip install --requirement "$${f}"
           done
 
           echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -225,6 +225,8 @@ jobs:
               pip3 install --requirement "$${f}"
           done
 
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
 

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -213,6 +213,12 @@ jobs:
           # to ensure that zaza installs correctly
           TEST_JUJU3: "1"
         run: |
+          # run in a virtualenv to ensure dependencies will not conflict with the system python packages
+          sudo apt install python3.10-venv -y
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
               pip3 install --requirement "$${f}"

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -214,7 +214,8 @@ jobs:
           TEST_JUJU3: "1"
         run: |
           # run in a virtualenv to ensure dependencies will not conflict with the system python packages
-          sudo apt install python3.10-venv -y
+          sudo apt update
+          sudo apt install python3-venv -y
           python3 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip


### PR DESCRIPTION
Currently `tics-analysis` job is running in a Jammy machine and trying to pip install dependencies directly onto the system Python. Some build-time tools might require newer version of certain package, but instead hits the older version that is shipped in the system by default. See an example issue: https://github.com/canonical/hardware-observer-operator/issues/519

We can create a virtualenv first and run pip install there to fully avoid system's packages.

Example fix: https://github.com/canonical/hardware-observer-operator/pull/520