### PR TITLE
fix: install pylint in virtual env for tics-analysis job

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -287,7 +287,7 @@ jobs:
           sudo apt install python3-venv -y
           python3 -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install coverage[toml]
+          .venv/bin/python -m pip install coverage[toml] pylint
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
@@ -300,7 +300,9 @@ jobs:
               .venv/bin/python -m pip install --requirement "$${f}"
           done
 
-          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+          # Symlink venv to a short path so TICS version string stays under 31 chars
+          sudo ln -s "$GITHUB_WORKSPACE/.venv" /opt/venv
+          echo "/opt/venv/bin" >> $GITHUB_PATH
 
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV

--- a/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
@@ -220,14 +220,16 @@ jobs:
           sudo apt install python3-venv -y
           python3 -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install coverage[toml]
+          .venv/bin/python -m pip install coverage[toml] pylint
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
               .venv/bin/python -m pip install --requirement "$${f}"
           done
 
-          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+          # Symlink venv to a short path so TICS version string stays under 31 chars
+          sudo ln -s "$GITHUB_WORKSPACE/.venv" /opt/venv
+          echo "/opt/venv/bin" >> $GITHUB_PATH
 
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -214,14 +214,16 @@ jobs:
           sudo apt install python3-venv -y
           python3 -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install coverage[toml]
+          .venv/bin/python -m pip install coverage[toml] pylint
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"
               .venv/bin/python -m pip install --requirement "$${f}"
           done
 
-          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+          # Symlink venv to a short path so TICS version string stays under 31 chars
+          sudo ln -s "$GITHUB_WORKSPACE/.venv" /opt/venv
+          echo "/opt/venv/bin" >> $GITHUB_PATH
 
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV


### PR DESCRIPTION
Current tics-analysis fails because tics itself requires `pylint` for its preparation task. The runner might have this already but the virtual environment doesn't. See: 
https://github.com/canonical/dcgm-snap/actions/runs/25318987542/job/74225708435

Another issue is tics tries to record the version string of the Python interpreter, and it only allows the string with under 31 chars. See: 
https://github.com/canonical/dcgm-snap/actions/runs/25416047498/job/74547651410

Fix includes installing `pylint`, and symlink the virtualenv interpreter to a shorter path. Tics passed on these testings:
[dcgm-snap](https://github.com/canonical/dcgm-snap/pull/88)
[hardware-observer-operator](https://github.com/canonical/hardware-observer-operator/pull/520)
