### PR TITLE
add flake8 to tics environment

### DIFF
--- a/terraform-plans/templates/github/charm_check.yaml.tftpl
+++ b/terraform-plans/templates/github/charm_check.yaml.tftpl
@@ -287,7 +287,7 @@ jobs:
           sudo apt install python3-venv -y
           python3 -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install coverage[toml] pylint
+          .venv/bin/python -m pip install coverage[toml] pylint flake8
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"

--- a/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/dcgm_snap_check.yaml.tftpl
@@ -220,7 +220,7 @@ jobs:
           sudo apt install python3-venv -y
           python3 -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install coverage[toml] pylint
+          .venv/bin/python -m pip install coverage[toml] pylint flake8
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"

--- a/terraform-plans/templates/github/snap_check.yaml.tftpl
+++ b/terraform-plans/templates/github/snap_check.yaml.tftpl
@@ -214,7 +214,7 @@ jobs:
           sudo apt install python3-venv -y
           python3 -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install coverage[toml] pylint
+          .venv/bin/python -m pip install coverage[toml] pylint flake8
 
           for f in $(find -name '*requirements.txt'); do
               echo "$${f}"


### PR DESCRIPTION
Get this reminder today:

> Some of your projects are not being correctly analysed. It seems the Python package “flake8” is not installed in the agent running TiCS, which is needed for the Compiler Warning metric.
> 
>  
> 
> Please make sure this is present in the Python (virtual) environment. More information here: [ref](https://warthogs.atlassian.net/browse/TICSISSUES-163)

